### PR TITLE
Add Bambu Lab / OrcaSlicer AGPL blog post

### DIFF
--- a/src/content/blog/2026-05-26-bambu-agpl.md
+++ b/src/content/blog/2026-05-26-bambu-agpl.md
@@ -1,0 +1,461 @@
+---
+title: "Bambu Lab, OrcaSlicer, and the Fight Over Who Controls Your Printer"
+tags:
+  - 3d-printing
+  - bambu-lab
+  - open-source
+  - orcaslicer
+  - maker-community
+  - right-to-repair
+description: >-
+  Bambu Lab posted an official statement defending their GitHub takedown of an
+  OrcaSlicer fork. Nearly 1,000 community replies later, the trust crisis in
+  the 3D printing space is deeper than ever. Here's the full breakdown.
+pubDate: '2026-05-25 20:45 -0500'
+updatedDate: '2026-05-25 21:07 -0500'
+heroImage: '/images/posts/3d-printing/x1-cc-best_1800x1800.png'
+---
+
+On May 7, 2025, Bambu Lab posted an official announcement to their community
+forum titled *"Setting the Record Straight on Cloud Access and Community."* It
+was meant to defuse a controversy. Instead, it generated nearly 1,000 replies —
+almost all of them skeptical or outright hostile — and reignited a broader
+debate about ownership, open source, and the direction Bambu Lab is taking as
+a company. This post breaks down the full picture: what happened, what Bambu
+said, why the community isn't buying it, and what it means for the future of
+consumer 3D printing.
+
+## How We Got Here: A Brief History of Bambu Lab and Its Community
+
+To understand why this blew up so badly, you need to understand the unusual
+relationship Bambu Lab has with its user base.
+
+Bambu Lab burst onto the 3D printing scene in 2022 with the X1 Carbon — a
+machine that offered print speeds and reliability that left the competition
+looking embarrassed. For a hobby that had spent years accepting that printing
+was a fussy, manual process full of failed prints and tweaking, the X1C felt
+like a revelation. Bambu printers became aspirational hardware almost
+overnight, and the company grew at a pace that few hardware startups ever
+manage.
+
+But Bambu didn't build that early success in a vacuum. They built it with the
+help of two groups: the open-source software ecosystem they built on top of,
+and the maker/enthusiast community that became their most vocal advocates. On
+the software side, Bambu Studio — their official slicing and print management
+application — is derived from Slic3r, SuperSlicer, and PrusaSlicer. Bambu has
+publicly acknowledged this. These are open-source projects with years of
+community development behind them. Bambu took that foundation, added their
+own cloud and hardware integration layers, and released the result under the
+AGPL license.
+
+The enthusiast community, meanwhile, did what enthusiast communities do: they
+dug into the hardware, reverse-engineered protocols, built third-party tools,
+and created an ecosystem of utilities that made Bambu printers even better.
+OrcaSlicer — a community fork of Bambu Studio with additional features and
+improvements — became enormously popular, so much so that Bambu officially
+acknowledged and even endorsed it as a legitimate alternative slicer. The
+relationship between Bambu and the open-source community felt, for a while,
+genuinely collaborative.
+
+That era of goodwill started cracking in January 2025.
+
+## The Bambu Connect Controversy: When Trust First Broke
+
+In January 2025, Bambu Lab announced changes tied to a new middleware layer
+called "Bambu Connect." The details of the implementation triggered immediate
+alarm in the community. Users found themselves effectively forced to choose
+between two unacceptable options: stay on current firmware and lose meaningful
+local control over their printers, or freeze their firmware at an older version
+to preserve the direct-access workflows they had built around their machines.
+
+This was not a small software preference dispute. For many users — particularly
+those who had integrated Bambu printers into automation workflows, home
+assistant setups, or third-party print management systems — Bambu Connect
+represented a fundamental change in the post-purchase terms of product
+ownership. They hadn't bought a printer that required Bambu's middleware to
+operate. Now, suddenly, they were being told they did.
+
+The backlash was significant. After considerable public pressure, Bambu walked
+back parts of the Bambu Connect rollout. Developer Mode and expanded LAN Mode
+access were preserved or restored. But the damage to trust was already done —
+and crucially, the rollback didn't erase the fact that Bambu had tried to move
+in that direction in the first place. The community had learned something
+important about Bambu's intentions, and they didn't forget it.
+
+## The OrcaSlicer-BambuLab Takedown
+
+Four months later came the next flashpoint. A GitHub project called
+"OrcaSlicer-BambuLab" — a fork designed to restore or extend functionality for
+Bambu printer owners — appeared on GitHub. Bambu Lab submitted a takedown
+request, and the repository was removed. The developer reportedly received
+private communications from Bambu as well, the exact content of which has not
+been publicly disclosed — reportedly because Bambu asked the developer not to
+share the details of their demands.
+
+The community reaction was swift and furious. YouTube creators covered it, forum
+threads lit up, and legal commentary began circulating — including discussions
+about whether Bambu's own conduct might constitute AGPL violations. Against this
+backdrop, Bambu Lab posted their official statement.
+
+## What Bambu Lab Actually Said
+
+The official post, written by a Bambu Lab employee, made several distinct claims
+that are worth examining individually.
+
+**They support open source and the AGPL.** Bambu opened by affirming that they
+fully respect the AGPL license, support forking and modification, and have no
+issue with OrcaSlicer or other legitimate forks. This was framed as a
+foundational point: the controversy is not about open source at all.
+
+**The issue is specifically cloud impersonation.** Bambu's stated concern is
+narrow: a fork that injected falsified identity metadata into network
+communications, causing an unofficial client to appear identical to an official
+Bambu Studio client when communicating with Bambu's servers. This is the
+behavior they say they objected to — not the existence of the fork, not open
+source generally, not third-party clients as such.
+
+**This is a security risk, not just a policy preference.** Bambu argued that
+this type of impersonation can generate DDoS-like load patterns on their cloud
+infrastructure, threatening service stability for all users. They framed it as
+a platform security concern, citing past experience with similar issues.
+
+**Open source licenses govern code, not cloud service access.** Bambu made an
+explicit legal distinction: the AGPL grants rights over the code, but their
+cloud is a private service governed by a user agreement. Accessing it deceptively
+falls outside what any open-source license authorizes.
+
+**Local options exist for users who want them.** The post reminded users that
+Developer Mode, LAN Mode, and Bambu Connect are available for those who prefer
+not to depend on cloud connectivity.
+
+Taken at face value, this is a defensible position. Impersonating a client to
+gain access to someone's private server infrastructure is not something an
+open-source license protects, and the concern about load patterns is at least
+theoretically legitimate. The problem is that almost none of the community found
+this framing credible — and they had specific reasons why.
+
+## The Community's Response: Nearly 1,000 Replies of Skepticism
+
+The thread accumulated 967 replies within 18 days and logged over 10,900 views.
+The engagement numbers alone tell you something: this is not a niche controversy.
+Here is a detailed breakdown of the most substantive criticisms raised.
+
+### "You claim to respect the AGPL — but do you actually?"
+
+One of the first and most upvoted replies in the thread wasted no time cutting to
+an obvious counter-point. It quoted Bambu's statement that they "deeply respect
+the AGPL license" and immediately linked to an open GitHub issue with over 200
+comments — filed in February 2025, tagged as a "feature" request — alleging that
+Bambu Studio version 1.10.02.76 ships with *incomplete source code*, a potential
+AGPL violation.
+
+The AGPL (Affero General Public License) requires that if you distribute software
+built on AGPL-licensed code, you must make the complete corresponding source code
+available. If Bambu Studio's releases include proprietary components that aren't
+disclosed — particularly the closed-source network plugin that connects to their
+cloud — then Bambu's own compliance with the license they claim to "deeply respect"
+is in question. The community has been pointing this out for months. That Bambu
+chose to open their statement with an affirmation of AGPL respect, while this
+unresolved issue remains open, struck many readers as tone-deaf at best.
+
+### The AGPL Argument Goes Deeper: Three Possible Violations
+
+One of the most technically detailed posts in the thread, from a user named
+Brandavorn, went further than just pointing to incomplete source code. Quoting
+Bambu's own statement that "open-source licensing governs the code, but it does
+not grant unlimited or deceptive access to Bambu's private cloud infrastructure,"
+Brandavorn argued the logic runs in the opposite direction from what Bambu intends.
+
+The code the fork used to access Bambu's servers was *published by Bambu itself*
+in Bambu Studio, as AGPL-licensed code. A terms of service agreement cannot
+retroactively place restrictions on how people use code that was published under
+an open-source license — the AGPL governs the code, and Bambu published it. You
+can restrict access to your cloud server-side, but you cannot use a ToS to
+override what the AGPL permits people to do with the licensed code itself.
+
+The post went on to allege three distinct possible AGPL violations by Bambu:
+first, attempting to breach the freedom to modify by pressuring the takedown of
+an AGPL fork; second, attempting to breach the freedom to use AGPL-licensed code
+by dictating how users interact with the Linux pathway Bambu themselves published
+as open source; and third, shipping a closed-source network plugin that is
+dynamically linked into Bambu Studio at runtime — which, depending on how you
+read the AGPL's copyleft provisions on shared libraries, may constitute a copyleft
+violation in itself. The counter-argument from another user (hotellonely) was
+that the memory-space argument is not a clear-cut infringement and would need to
+be resolved in court — but the point that Bambu may have its own compliance
+problems was well-received.
+
+### "Your cloud isn't actually required to print"
+
+Another highly-liked early reply called the entire security framing a "moot
+argument." The commenter pointed out that Bambu's cloud services are not actually
+required to operate a Bambu printer — anyone who wants cloud features can use
+them, and anyone who doesn't can use LAN Mode or Developer Mode. The cloud is
+optional from the user's perspective.
+
+If the cloud is optional, then the argument that third-party clients are
+"threatening cloud stability for all users" falls apart. Users aren't being forced
+off the cloud against their will by rogue clients — they're choosing to use the
+cloud, and the fork in question was trying to give them a better way to do so.
+The real concern, this user argued, is that Bambu fears losing their position as
+the sole gatekeeper of how users interact with their own hardware. If better
+third-party clients exist, users might prefer them — and Bambu loses control of
+the user experience and, potentially, the data that flows through it.
+
+### "A user_agent string isn't a security threat"
+
+Perhaps the most technically pointed reply in the early thread came from a user
+who dug into the actual code and identified what the "falsified identity metadata"
+appears to actually be: a `user_agent` string. Here is the relevant code snippet
+that was shared:
+
+```cpp
+std::string plarczsak_user_agent = SLIC3R_APP_NAME "/" %SoftFever_VERSION%;
+#if defined(__WINDOWS__)
+    if (Slic3r::PlarczszkLinuxBridge::enabled())
+        plarczsak_user_agent = std::string("BambuStudio/") +
+            Slic3r::PlarczszkLinuxBridge::forced_client_version();
+#endif
+llcurl_easy_setopt(curl, CURLOPT_USERAGENT, plarczsak_user_agent.c_str());
+```
+
+A `user_agent` string is a plain text identifier that client software sends to
+servers to identify itself. It is one of the least robust identifiers imaginable
+— trivially spoofed, not a cryptographic credential, not a meaningful security
+boundary by any reasonable standard. Framing the use of a `user_agent` string as
+a vector for DDoS-like attacks and a serious threat to platform integrity drew
+considerable skepticism. The commenter also noted that Bambu's bug bounty program
+doesn't publicly list payout amounts — which, in a thread where Bambu is claiming
+to care deeply about security, didn't help their credibility.
+
+The counter-argument from Bambu's defenders was that impersonation itself is the
+legal problem, regardless of how technically simple the mechanism is — and that
+is a fair point. But the gap between "we objected to a user_agent string" and "we
+had to take down a GitHub repo to protect cloud stability" is wide enough that
+many people found Bambu's threat framing disproportionate.
+
+### "Terms of service cannot override AGPL-licensed code"
+
+Brandavorn's reply also surfaced a legal point that has been circulating in
+open-source legal circles: Bambu published the connection code as AGPL-licensed
+source. The fork used that code. Bambu's terms of service cannot dictate how
+people use code that Bambu themselves published under a license that explicitly
+grants usage and modification rights. If you want to restrict server-side access,
+you do it server-side — with authentication, with rate limiting, with IP blocking.
+You don't do it by pressuring a developer to take down an AGPL-licensed fork on
+GitHub.
+
+This argument points at something that other commenters echoed throughout the
+thread: Bambu's legal options for controlling their cloud are real, but they chose
+a much more aggressive tool than server-side enforcement. A cease-and-desist
+targeting a GitHub repository — accompanied by reported private pressure on the
+developer not to disclose the demands — is a much louder statement than a server
+configuration change would be.
+
+### "This is Tivoization — and we've seen this movie before"
+
+Multiple users invoked the concept of [Tivoization](https://en.wikipedia.org/wiki/Tivoization)
+— a term coined to describe TiVo's practice of using hardware restrictions to
+prevent users from running modified GPL-licensed software on their devices.
+Tivoization was considered so problematic by the open-source community that the
+GPLv3 license was specifically written to prohibit it. While the AGPL situation
+with Bambu is not a direct parallel, the underlying dynamic is the same:
+a company benefits from open-source software, builds it into a product, and then
+uses other mechanisms (hardware, cloud control, legal pressure) to prevent users
+from exercising the freedoms that the open-source license was supposed to guarantee.
+
+One user drew a direct comparison to Sonos — a company that built enormous
+goodwill with a technical community by making a genuinely great product, then
+progressively changed the terms of the relationship through software updates,
+app redesigns, and feature removals until the community felt betrayed. "Think
+Sonos speaker debacle. You are going too far down the Apple path." The Apple
+comparison is equally apt: Apple has perfected the art of building a premium
+ecosystem that users love right up until the moment they try to leave it or
+work outside its walls.
+
+The message in the thread was consistent: this is a pattern the tech-savvy
+community recognizes, and they're not going to be told it isn't happening while
+it's happening.
+
+### The Most Thorough Critique: A Structured Takedown
+
+One community member — a veteran forum user and moderator — posted what became
+the most comprehensive critique in the thread, notable for being unusually fair
+to Bambu before dismantling their position. It is worth covering in some detail.
+
+The post opened by conceding Bambu's core legal point: Bambu has the right to
+control access to its own cloud infrastructure. The AGPL does not give anyone
+unlimited or deceptive access to a private cloud service. If a third-party client
+was genuinely presenting itself as an official Bambu Studio client to gain cloud
+access, Bambu has a legitimate basis to object to that specific behavior. This
+was a deliberate concession, not a throwaway — and it made the rest of the
+argument more credible as a result.
+
+But, the post argued, that narrow point does not resolve the larger problem.
+
+Bambu built its early success on enthusiasts and early adopters who believed they
+were buying hardware they would own — not renting access to it under whatever
+access model Bambu might later choose to impose. Those early buyers supported
+Bambu when the company was still an unproven startup. They reasonably expected
+the same ownership rights that have historically come with physical hardware: the
+ability to use local workflows, third-party software, and custom integrations
+without requiring permission from or payment to the manufacturer.
+
+The Bambu Connect controversy in January 2025 changed those conditions after the
+sale. It told existing owners — who bought their printers under one set of
+expectations — that the rules had changed. That is a different category of
+problem from a product decision that only affects future buyers. And while Bambu
+walked it back, the rollback doesn't undo the lesson learned: Bambu was willing
+to go there.
+
+The post then made what may be its most pointed demand: if this is truly only
+about cloud impersonation, then *prove it publicly*. Publish the technical
+boundary. Identify the specific behavior that crossed the line. Separate cloud
+access from LAN/local control. Separate actual server impersonation from
+restoring functionality that owners previously had. Separate copyright claims
+from contract claims from security claims.
+
+Instead, Bambu chose opacity — making broad public claims about the fork while
+reportedly pressuring the developer not to reveal the private demands. That
+asymmetry is the heart of the distrust. A company confident in the legitimacy of
+its position does not need to hide the specifics.
+
+The open-source angle was called out explicitly: Bambu Studio's lineage runs
+through Slic3r, SuperSlicer, and PrusaSlicer. Bambu acknowledges this. They
+benefited from that ecosystem — the years of community labor that went into those
+slicers, the culture of sharing that produced them, the enthusiast community that
+embraced and extended their products. Now, when the community extends things in
+directions Bambu dislikes, Bambu reaches for legal pressure. "Open source is not
+'you may enhance this only when it preserves our commercial control.'"
+
+The closing line became something of a rallying point in the thread: *"Bambu can
+control its cloud. That is not the dispute. The dispute is whether Bambu owners
+control their printers. Right now, Bambu's actions keep answering that question
+in the wrong direction."*
+
+### The Other Side: Bambu Has Defenders Too
+
+To be fair, the thread was not a unanimous chorus of condemnation. There were
+users who pushed back on the critics, and some of their points deserve
+acknowledgment.
+
+One user argued at length that most of the criticism was being driven by a small
+vocal minority who "attack Bambu under the banner of open source" but whose actual
+grievances are more about control and ideology than about the interests of typical
+Bambu customers. They pointed out that Bambu's cloud is central to the MakerWorld
+ecosystem — including designer credit tracking, boost distribution, and the social
+features that make MakerWorld valuable for the large community of designers who
+create and share models. Disrupting the cloud with rogue clients doesn't just
+hurt Bambu; it potentially hurts the thousands of designers and users who depend
+on those services working reliably.
+
+Another user asked a genuinely fair question: isn't LAN mode exactly what the
+critics say they want? If you want local access, Developer Mode gives you local
+access. If you want to use third-party slicers, they work fine with LAN Mode.
+What exactly is the gap between what Bambu provides and what critics are
+demanding?
+
+The critics' response to this is that LAN Mode and Developer Mode are tolerated
+exceptions, not documented, stable, contractual ownership rights. There is no
+guarantee Bambu won't change or restrict those modes in a future firmware update.
+The January 2025 controversy is precisely the proof of that concern. You can't
+build workflows around access modes that the manufacturer can revoke at will.
+
+## The Broader Stakes: This Is About More Than One GitHub Repo
+
+It would be easy to frame this as a niche spat between Bambu and a subset of
+power users who want more control than any reasonable company should be expected
+to provide. That framing misses what's actually at stake.
+
+The 3D printing community sits at the intersection of several movements that care
+deeply about ownership, repairability, and digital rights: the maker movement, the
+right-to-repair movement, and the open-source software community. These aren't
+fringe groups. They represent a meaningful portion of Bambu's early and most
+passionate customer base. When Bambu's actions are perceived as moving toward
+the Apple/Sonos/TiVo model — where the manufacturer progressively tightens
+control over devices you've already paid for — those communities notice, and
+they respond loudly.
+
+There's also a practical question about long-term product support. If Bambu's
+cloud infrastructure changes, is deprecated, or requires a subscription in the
+future, what happens to devices that depend on it? Printers are physical objects
+expected to last years or decades. A local-first, open-protocol design means your
+printer keeps working regardless of what happens to the company. A cloud-dependent
+design means your printer's future is tied to Bambu's business decisions in
+perpetuity. That is a risk calculus that matters to buyers making a significant
+hardware investment.
+
+Finally, there is the question of what this signals for the open-source ecosystem
+more broadly. If Bambu succeeds in using legal pressure to shut down community
+forks that restore or extend functionality, it sets a precedent. Other hardware
+companies watching this space will note that the approach works. The open-source
+slicer ecosystem — PrusaSlicer, SuperSlicer, OrcaSlicer, BambuStudio — exists
+because of a culture of sharing and building on each other's work. Using legal
+tools to carve out proprietary control within that ecosystem, while continuing to
+benefit from the open-source foundation, is corrosive to the culture that made
+the ecosystem valuable in the first place.
+
+## What Would Actually Rebuild Trust
+
+The community's demands across nearly 1,000 replies have been remarkably
+consistent. They aren't asking Bambu to abandon their cloud business or give up
+control of their servers. They're asking for a set of commitments that any
+company serious about honoring the open-source relationship should be able to
+make:
+
+Publish clear, stable, documented local APIs. Not developer mode as a tolerated
+exception, but a formal, documented interface that users can build on with
+confidence it won't be revoked. Give the community something they can rely on.
+
+Separate cloud functionality from local printer control completely. Firmware
+updates should never come bundled with changes to local access. The two concerns
+are orthogonal and should be treated that way.
+
+Resolve the outstanding AGPL compliance questions. If Bambu genuinely respects
+the AGPL, the open GitHub issue alleging incomplete source code should be closed
+with a substantive response, not left to sit with 200+ comments and no resolution.
+
+Be transparent about legal actions. If Bambu sends a cease-and-desist to an
+open-source developer, the community expects at minimum a clear public explanation
+of the specific technical behavior that crossed the line — not a broad framing
+that paints the entire fork as a threat while keeping the actual demands private.
+
+Stop treating third-party control as a favor. LAN Mode and Developer Mode should
+be documented, contractual features — not toggles that can be flipped in a future
+firmware update. If Bambu wants to be believed when they say they support local
+control, they need to commit to it in a way that can't be quietly reversed.
+
+## Conclusion: The Dispute Is About Who Owns the Printer
+
+Bambu Lab makes genuinely good printers. That's not in dispute. For a huge segment
+of buyers — people who want to print reliably without getting deep into machine
+tuning — a Bambu printer with Bambu's cloud and ecosystem is a great product at
+a competitive price. There is a legitimate user base for exactly that offering.
+
+But there is also a legitimate user base for people who want to own their hardware
+in a more complete sense: to control the software it runs, to integrate it with
+third-party tools, to build workflows that don't depend on any single company's
+cloud remaining available and free. Bambu built much of its early success by being
+appealing to *both* groups. The current trajectory is moving away from the second
+group — and the second group is pushing back.
+
+The January 2025 Bambu Connect controversy showed that Bambu is willing to change
+post-purchase access conditions when it suits them. The OrcaSlicer-BambuLab
+takedown showed they're willing to use legal pressure against community developers.
+The forum thread showed that the community is paying close attention, has long
+memories, and isn't interested in corporate-friendly language that sidesteps the
+actual questions.
+
+Bambu can control their cloud. Nobody is seriously disputing that. The dispute
+is simpler and more fundamental: when you buy a Bambu printer, do you own it?
+Right now, Bambu's actions keep pointing toward the same answer — and it isn't the
+one the community wants to hear.
+
+---
+
+*Sources: [Bambu Lab Community Forum — "Setting the Record Straight on Cloud Access
+and Community" (May 7,
+2025)](https://forum.bambulab.com/t/setting-the-record-straight-on-cloud-access-and-community/252164)*
+
+Disclaimer: This article is journalistic commentary based on publicly available
+reporting and forum documents. Nothing herein constitutes legal advice.


### PR DESCRIPTION
## Summary

- Adds a new long-form blog post breaking down Bambu Lab's May 7, 2025 "Setting the Record Straight on Cloud Access and Community" statement and the OrcaSlicer fork GitHub takedown
- Covers the community response (~1,000 mostly skeptical replies), the AGPL questions raised by the takedown, and what the episode signals about consumer-3D-printing ownership and open source

## Changes

- **src/content/blog/2026-05-26-bambu-agpl.md**: new post; reuses an existing hero image at `public/images/posts/3d-printing/x1-cc-best_1800x1800.png`

## Test Plan

- [x] `npm run dev` and confirm the post renders at `/blog/2026-05-26-bambu-agpl/`
- [x] Confirm hero image loads
- [x] Confirm title, pubDate, and tags render correctly (no duplicate H1)
- [x] Confirm the post appears on the blog index and in RSS
- [x] `npm run build` succeeds with no content schema errors