### PR TITLE
Add leaked Bricks & Minifigs crisis memo post

### DIFF
--- a/src/content/blog/2026-05-28-leaked-bam-memo.md
+++ b/src/content/blog/2026-05-28-leaked-bam-memo.md
@@ -1,0 +1,193 @@
+---
+pubDate: '2026-05-28 14:00 -0500'
+heroImage: '/images/bam.webp'
+tags:
+  - bricks-and-minifigs
+  - lego
+  - star-wars
+  - oregon-law
+  - franchise-liability
+  - reckless-ben
+  - anti-slapp
+  - accountability
+description: >-
+  A purported internal Bricks & Minifigs corporate memo to franchisees — coaching
+  them on canned scripts, comment shutdowns, review flagging, platform takedowns,
+  and a "from defense to offense" legal campaign — leaked through the latest
+  Reckless Ben video. Why the memo, if authentic, undercuts BAM's "independent
+  franchisee" defense, and how Oregon's anti-SLAPP statute (ORS 31.150),
+  prior-restraint doctrine, and the FTC's review rule frame what it describes.
+canonical: https://fusion94.org/blog/2026-05-28-bricks-and-minifigs-leaked-memo/
+meta-description: A purported internal Bricks & Minifigs corporate memo to franchisees — coaching them on canned scripts, comment shutdowns, review flagging, platform takedowns, and a "from defense to offense" legal campaign against Reckless Ben — leaked through the latest video. Why the memo, if authentic, undercuts BAM's "independent franchisee" defense, and how Oregon's anti-SLAPP statute (ORS 31.150), prior-restraint doctrine, and the FTC's review rule frame what it describes.
+meta-generator: Astro v6.1.9
+meta-og:description: A purported internal Bricks & Minifigs corporate memo to franchisees — coaching them on canned scripts, comment shutdowns, review flagging, platform takedowns, and a "from defense to offense" legal campaign against Reckless Ben — leaked through the latest video. Why the memo, if authentic, undercuts BAM's "independent franchisee" defense.
+meta-og:image: https://fusion94.org/images/bam.webp
+meta-og:title: The Leaked Bricks & Minifigs Crisis Memo — How Corporate's Own Playbook Undercuts Its "Independent Franchisee" Defense
+meta-og:type: website
+meta-og:url: https://fusion94.org/blog/2026-05-28-bricks-and-minifigs-leaked-memo/
+meta-title: The Leaked Bricks & Minifigs Crisis Memo — How Corporate's Own Playbook Undercuts Its "Independent Franchisee" Defense
+meta-twitter:card: summary_large_image
+meta-twitter:description: A purported internal Bricks & Minifigs corporate memo to franchisees leaked through the latest Reckless Ben video. Why it undercuts BAM's "independent franchisee" defense, and how Oregon's anti-SLAPP statute frames the takedown campaign it describes.
+meta-twitter:image: https://fusion94.org/images/bam.webp
+meta-twitter:title: The Leaked Bricks & Minifigs Crisis Memo — How Corporate's Own Playbook Undercuts Its "Independent Franchisee" Defense
+meta-twitter:url: https://fusion94.org/blog/2026-05-28-bricks-and-minifigs-leaked-memo/
+meta-viewport: width=device-width,initial-scale=1
+title: The Leaked Bricks & Minifigs Crisis Memo — How Corporate's Own Playbook Undercuts Its "Independent Franchisee" Defense
+---
+
+*A follow-up to [How Bricks & Minifigs Allegedly Stole an Old Man's Star Wars LEGO Collection — And Why the Internet Is Burning It Down](https://fusion94.org/blog/2026-05-25-bricks-and-minifigs/) (May 25, 2026).*
+
+
+Three days ago I published a long walkthrough of the Mansell / Bricks & Minifigs case: the $200,000 Star Wars LEGO collection, the November 2024 store seizure, the removed ownership stickers, the test purchase that caught the new operators selling consigned sets after denying they had them, and the Oregon statutes and case law that frame all of it. The central legal argument of that piece was about **control** — that BAM Franchising's "we're just the franchisor, the location is independently owned" defense collapses under *Viado v. Domino's Pizza* the moment you show corporate directly running the relevant operations.
+
+Since then, the story has moved fast. And a new artifact has surfaced that goes directly to that control question — arguably more directly than anything in the public record so far.
+
+In his latest video, Reckless Ben reads through what he presents as a **leaked internal email from BAM corporate to its franchise network**, instructing store owners on how to handle the fallout from his coverage. If it is what it claims to be, it is the company's own crisis-management playbook. And the playbook is far more revealing than the polished blog post BAM put out on May 21.
+
+**A necessary caveat up front, and I want to be as careful with this as I was with everything in the first post:** I cannot independently authenticate this memo. It surfaced through a YouTube video, not through a primary-source outlet like the *Salem Business Journal*, which reviewed the consignment agreement and metadata directly. Ben says it "leaked online" and that someone forwarded it to him. BAM has already pre-positioned the defense that the recordings against it are "doctored" and that "serious claims require serious evidence." That cuts both ways. So everything below is conditional: **if** the memo is genuine, here is what it shows, and here is the law it runs into. Where I quote it, I quote short and sparingly, and I paraphrase the rest.
+
+---
+
+## Part One: What the Memo Says It Is
+
+The document is framed as guidance to "our franchises" on responding to what corporate characterizes as a coordinated negative-PR attack stemming from a former franchisee's consignment dispute in the Salem area. It acknowledges that the situation has produced harassment calls, review-bombing, and store disruptions "across our network."
+
+Sit with that framing for a moment. The very first move is to recast a documented accountability story — one with a signed consignment agreement, timestamped photos, security footage in police custody, and a 30-page investigation with the Marion County DA — as a *coordinated attack*. Not "a serious allegation we are investigating." A campaign. The author's instinct, on page one, is that the problem is the criticism, not the conduct that produced it.
+
+The memo then pivots to posture. In a line that does most of the work, it announces a shift **"from defense to offense"** — that the company will no longer merely defend its actions but will move against Reckless Ben directly. It states that while BAM will not litigate the matter in the media, it is taking aggressive action behind the scenes.
+
+That sentence is worth flagging, because it inverts the normal logic of innocence. A party confident in its facts and worried about reputation usually *wants* the record public. Choosing to fight "behind the scenes" while seeking to remove the public's access to the other side's account is the posture of a party trying to control what can be seen, not what is true. Reasonable people can read that differently — but it is, at minimum, in tension with the company's public claim that it simply wants the facts to come out.
+
+---
+
+## Part Two: "Corporate Was Not Involved" — Next to a Network-Wide Operations Order
+
+Here is the contradiction at the heart of the document.
+
+The memo reportedly repeats the company's core line: that **corporate was not involved in the specific local consignment issue** and is "holding firm on the facts." That is the same defense from the May 21 blog post — the independent-franchisee shield I spent a third of the original article taking apart.
+
+But look at what the memo *is*. It is a centralized directive issued to the entire franchise network, prescribing:
+
+- Verbatim scripts for frontline staff to recite to customers and journalists
+- Instructions to disable comments on individual stores' social media
+- A coordinated review-monitoring and review-flagging protocol
+- A unified outreach effort to Google/YouTube, Patreon, GoDaddy, and Facebook
+- A centralized legal strategy, including a planned restraining order "against all parties"
+- A request that none of this internal strategy be shared with customers, lest it "compromise our active legal case against Ben Schneider"
+
+You cannot simultaneously claim to be a hands-off franchisor with no involvement in local operations **and** issue a binding, network-wide communications-and-legal playbook with memorized scripts. The memo is itself evidence of exactly the kind of operational control that, under *Viado v. Domino's Pizza*, 230 Or. App. 531 (2009) and *Miller v. McDonald's Corp.*, 150 Or. App. 274 (1997), removes the independent-contractor shield. The test in those cases is whether the franchisor controls "the specific part of its business that allegedly resulted in plaintiff's injuries." A company that scripts what its stores are allowed to say about the Mansell collection, and that coordinates the legal response to it from the top, is exercising control over precisely the part of the business at issue.
+
+And recall what the original reporting already established: the Gormans allege that BAM's own Director of Operations acknowledged the consignment **on the night of the seizure**, on a call captured by the store's security camera now in police possession. "Corporate was not involved" is a difficult sentence to reconcile with corporate's operations chief allegedly being on the phone, by name, accepting the consignment as part of the handover. The leaked memo does not address that allegation either. The silence in the public blog post is now a silence in the internal memo too.
+
+---
+
+## Part Three: The Takedown Campaign and the Silencing Problem
+
+The memo's enforcement strategy has three prongs, and each one collides with a body of law worth naming.
+
+**A restraining order against speech.** The memo describes the legal team preparing direct claims and seeking a temporary restraining order to "halt the harassment" and push the matter to full litigation against all parties. Read charitably, harassment and genuine threats are not protected speech, and a business has every right to pursue people who cross that line. But a TRO that would restrain *publication* — that would order platforms to remove videos and commentary about a matter of obvious public concern — runs headlong into the doctrine of **prior restraint**, which carries one of the heaviest presumptions of unconstitutionality in American law. *See Near v. Minnesota*, 283 U.S. 697 (1931); *Nebraska Press Assn. v. Stuart*, 427 U.S. 539 (1976). Courts do not lightly issue orders telling people they may not speak about a public dispute, and they are especially reluctant where the "harassment" and the "criticism" are intertwined.
+
+**Oregon's anti-SLAPP statute.** This is the legal hook that the memo, if genuine, should worry BAM's counsel the most. Oregon has a robust anti-SLAPP law — **ORS 31.150** — that provides a special motion to strike claims arising from statements or conduct "in connection with an issue of public interest" or made in a public forum. A defamation or related suit brought primarily to suppress a viral, well-documented public-interest exposé is close to the paradigm case the statute was written to deter. If BAM files the "direct claims" the memo describes and a court finds they target protected speech on a matter of public interest, the company could face not only dismissal but a mandatory award of the *defendants'* attorney fees under ORS 31.152. A litigation strategy designed to impose cost and silence can, under that statute, recoil onto the party that brought it.
+
+**Disabling comments and flagging reviews.** The memo reportedly recommends that stores turn off commenting on their social posts and actively flag negative reviews as spam or retaliatory. Set this beside the company's repeated public insistence that it is *not* trying to silence criticism. Turning off the public's ability to comment, and reporting genuine critical reviews for removal, is — definitionally — an effort to reduce the visibility of criticism. One can defend it as ordinary crisis hygiene against a brigading campaign. One cannot defend it while also claiming not to be doing it.
+
+---
+
+## Part Four: The Review Playbook and the FTC Problem
+
+The review section deserves its own treatment, because it edges from PR into regulated territory.
+
+The memo reportedly pairs two instructions: flag and report negative reviews for removal, **and** instruct staff to solicit a Google review from customers at the register with "every single transaction." Soliciting honest reviews is legal and routine. Selectively suppressing genuine negative reviews while simultaneously pumping the channel with freshly solicited positive ones is a different animal. It is the mechanics of **review gating** — shaping the public rating not by improving conduct but by managing which feedback survives.
+
+This matters because the **FTC's Rule on the Use of Consumer Reviews and Testimonials** (16 C.F.R. Part 465), in effect since 2024, specifically targets the suppression and manipulation of consumer reviews, including practices that misrepresent that displayed reviews are representative when negative reviews have been suppressed. I am not asserting a violation — that requires facts I don't have about what was actually flagged and why. But a network-wide directive to scrub the negative and manufacture the positive is exactly the conduct the rule was written to reach, and it is a strange thing to put in writing during a dispute that is already drawing federal-agency attention.
+
+---
+
+## Part Five: Treating Accountability Like Weather
+
+The most telling section, to me, is the one that tries to be reassuring. The memo lays out a predicted "outrage cycle" — an initial wave of peak intensity lasting a few days, a renewed spike when legal filings drop, a decay phase of a few weeks, and long-term reputational recovery within a few months — and counsels franchisees to simply wait it out.
+
+There are two problems with this, one tactical and one moral.
+
+The tactical problem is that the model was wrong almost immediately. The memo appears to have been drafted when Ben's video had a fraction of the views it now has; the coverage has since expanded to Kotaku, Dexerto, and a widening circle of outlets, and the view counts have multiplied rather than decayed. More to the point, the memo's own recommended strategy — filing suit — is what guarantees the cycle *won't* fade. Litigation is a multi-year content engine. A company that wanted the attention to dissipate chose the one path that ensures fresh filings, hearings, and headlines for years. The memo predicts a renewed spike at the moment of filing and then recommends filing anyway.
+
+The moral problem is the framing itself. The document treats a documented allegation of elder financial exploitation as a weather system to be endured — something that will pass if everyone stays quiet long enough. It contains, as far as the leaked text shows, no instruction to *investigate whether the underlying allegation is true*, no instruction to locate and return the remaining sets, no instruction to make the elder Mr. Mansell whole. The entire energy is directed at managing perception. The simplest path off the front page was always the one the original post identified: return the property or pay for it. The memo reaches for scripts instead.
+
+---
+
+## Part Six: The Scripts
+
+The memo reportedly includes memorized, verbatim responses for staff and a downloadable "de-escalation playbook" covering in-store filming, hostile phone calls, and social comments. The recurring instruction to employees is to **not engage emotionally** and to recite that the location is separate and independently owned, with no information to share.
+
+Two observations.
+
+First, the "independently owned, no information" script is the franchisor shield translated into a customer-service mantra — pushed down to teenagers behind a register who had nothing to do with Keizer, Oregon. Whatever its legal utility for corporate, it places innocent franchisees and their staff in the position of stonewalling on corporate's behalf. The reporting since my last post suggests some franchisees are uneasy about exactly that, and I have sympathy for them. The stores being asked to read these lines are not the ones who seized anyone's collection.
+
+Second, "do not engage emotionally" is, in isolation, genuinely sound crisis advice. The irony is that the company is reportedly distributing it network-wide precisely because the conduct at the center of the storm — by the company's own account of events — was not handled with anything resembling that discipline.
+
+I'll note one item I am *not* relying on: Ben relayed a secondhand claim that an employee was fired over a friend's comment on the company's channel. I have no way to verify that and I'm not treating it as established. I mention it only to be transparent that it was said and that it should be treated as an unverified allegation, not a fact.
+
+A word on the theatrical elements, since BAM will surely point to them. Ben's parody "rival" website mocking the company, the costume bits, the stunts — these are real, and they are deliberately absurd. They are also, structurally, the same *Nathan For You*–style provocation I described in the first post: the goal is to bait a 300-location company into court, where the documents can be tested, because the Mansells cannot afford to initiate that fight themselves. You can find the methods juvenile and still recognize that the underlying paper trail — the agreement, the photos, the footage, the test purchase — does not become less real because the person surfacing it is wearing a costume.
+
+---
+
+## Part Seven: Where Things Stand Now
+
+A lot has happened in three days. Pulling the threads together as of this writing, May 28, 2026:
+
+- **Part two is out.** Ben has released a roughly 41-minute continuation on Patreon, with the next installment promised on YouTube.
+- **The lawsuit was rejected, then refiled.** Ben's initial suit against the current operators — identified in newer reporting as **Brandon Best** and **Joshua Johnson** — was reportedly rejected for failure to demonstrate a "good faith effort" to resolve the dispute first. He then documented an attempt to do exactly that (Johnson had apparently blocked him), and reporting indicates subsequent filings were accepted by the court.
+- **A default-judgment motion and a closure.** The Keizer store was reported temporarily closed after Ben filed a motion for default judgment.
+- **The fundraiser.** A GoFundMe for the Mansell family has reportedly passed $12,000 toward a $28,000 goal.
+- **The corporate org chart.** Newer coverage names **Matt McNeff** as COO alongside CEO **Ammon McNeff**, and puts the chain at roughly **300 locations** across the U.S. and Canada — a larger network than the figure I cited in the first post, and a larger set of franchisees now caught in the middle.
+- **The unverified misconduct claims.** Ben continues to allege serious law-enforcement misconduct around his Utah and Oregon investigations. As I said last time, these remain **unproven in any official proceeding**, and I'm holding them at arm's length until they aren't.
+- **The DA.** I have seen no public charging decision from the Marion County District Attorney since my last post. The 30-page investigation remains, as far as the public record shows, under review.
+
+---
+
+## Conclusion: The Memo Argues Against the Company That Wrote It
+
+I want to restate the boundary clearly, because it matters more with this post than the last. **I cannot authenticate this memo.** It reached the public through a YouTuber's video. BAM has pre-loaded the argument that the evidence against it is fabricated. A careful reader should hold the document as alleged until a primary source verifies it — the same standard I'd want applied to anything I publish.
+
+But if it is real, it is self-defeating in a specific and legally meaningful way. The company's entire public defense rests on a single proposition: that it is a distant franchisor with no hand in local operations. The leaked memo is a centralized order directing local operations — what stores may say, which comments they may allow, which reviews they may flag, what their legal posture will be. You cannot wave the independent-franchisee flag with one hand while issuing a network-wide script with the other. Under *Viado* and *Miller*, that kind of control is the whole ballgame.
+
+And the strategy it lays out — a speech-restraining TRO, coordinated platform takedowns, comment shutdowns, review management, a "from defense to offense" campaign against a critic — is the conduct that Oregon's anti-SLAPP statute, the prior-restraint doctrine, and the FTC's review rule were each written to discourage. A company genuinely confident in its facts does not usually need to manage the visibility of the other side this aggressively. It produces the documentation it has been asked for, returns or pays for the property, and lets the record speak.
+
+Bryan Mansell's father is 83. The path off the front page has not changed since I wrote it three days ago. It was never a script. It was always step one: give the LEGO back, or pay what it's worth.
+
+I still hope he gets it.
+
+---
+
+## Legal Authorities Referenced in This Article
+
+- **ORS 31.150–31.155** — Oregon's anti-SLAPP statute; special motion to strike claims arising from statements or conduct in connection with an issue of public interest, with a mandatory attorney-fee award to a prevailing defendant under ORS 31.152.
+- ***Near v. Minnesota***, 283 U.S. 697 (1931) — Foundational prior-restraint case; heavy presumption against orders restraining publication.
+- ***Nebraska Press Assn. v. Stuart***, 427 U.S. 539 (1976) — Prior restraints on speech bear a heavy presumption of unconstitutionality.
+- ***Viado v. Domino's Pizza, LLC***, 230 Or. App. 531, 217 P.3d 199 (2009) — Franchisor may be liable where it controls the specific part of operations that caused the harm (right-to-control test).
+- ***Miller v. McDonald's Corp.***, 150 Or. App. 274, 945 P.2d 1107 (1997) — Distinguishes standards-setting from operational control for franchisor liability.
+- **16 C.F.R. Part 465** — FTC Rule on the Use of Consumer Reviews and Testimonials (effective 2024); addresses suppression and manipulation of consumer reviews.
+
+*(For the underlying theft, elder-abuse, and conversion authorities — ORS 164.085, 164.095, 164.057, 164.061, 124.100, and Mustola v. Toddy — see the [original post](https://fusion94.org/blog/2026-05-25-bricks-and-minifigs/).)*
+
+---
+
+## Sources and Further Reading
+
+- [Original post: How Bricks & Minifigs Allegedly Stole an Old Man's Star Wars LEGO Collection](https://fusion94.org/blog/2026-05-25-bricks-and-minifigs/)
+- [Salem Business Journal: Keizer LEGO dispute and criminal investigation](https://salembusinessjournal.org/2026/03/30/keizer-lego-dispute-star-wars-collection/) — *the definitive primary-source report.*
+- [Kotaku: YouTuber starts a cult and is raided by police in attempt to recover old man's Star Wars LEGO collection](https://kotaku.com/youtuber-starts-a-cult-and-is-raided-by-police-in-attempt-to-recover-old-mans-star-wars-lego-collection-2000699026)
+- [Dexerto: Dispute over $200k LEGO Star Wars collection triggers lawsuits and viral investigation](https://www.dexerto.com/youtube/dispute-over-200k-lego-star-wars-collection-triggers-lawsuits-and-viral-investigation-3367546/)
+- [The Express Tribune: Scandal deepens as Reckless Ben claims arrest and raises questions over CEO](https://tribune.com.pk/story/2610288/bricks-and-minifigs-lego-scandal-deepens-as-reckless-ben-claims-arrest-and-raises-questions-over-ceo)
+- [Primetimer: Who is Ammon McNeff? CEO comes under fire as the controversy intensifies](https://www.primetimer.com/features/who-is-ammon-mcneff-bricks-and-minifigs-ceo-comes-under-fire-as-reckless-ben-patreon-lego-controversy-intensifies)
+- [Bricks & Minifigs corporate statement (May 21, 2026)](https://bricksandminifigs.com/blog/blog/2026/05/21/salem-oregon-bricks-and-minifigs-store-situation/)
+- [Oregon anti-SLAPP statute: ORS 31.150](https://oregon.public.law/statutes/ors_31.150)
+- [FTC: Rule on the Use of Consumer Reviews and Testimonials](https://www.ftc.gov/legal-library/browse/rules/use-consumer-reviews-testimonials-rule)
+
+---
+
+*Tony Guntharp writes at fusion94.org about technology, open source, and the things that matter. He is also a LEGO collector and knows exactly how much those Star Wars sets are worth.*
+
+---
+
+*Disclaimer: This article is journalistic commentary based on publicly available reporting and on a leaked document whose authenticity has not been independently verified. Nothing herein constitutes legal advice. All allegations described remain unproven in court. Readers seeking legal guidance regarding specific situations should consult a licensed Oregon attorney.*


### PR DESCRIPTION
## Summary

- Adds a follow-up blog post to the Mansell / Bricks & Minifigs case, analyzing a purported leaked internal BAM corporate memo to its franchise network.
- Argues that a network-wide operations directive (scripts, comment shutdowns, review flagging, platform takedowns, a centralized legal strategy) is in tension with BAM's "independent franchisee" defense.
- Frames the described takedown campaign against Oregon's anti-SLAPP statute (ORS 31.150), prior-restraint doctrine, and the FTC's review rule.

## Changes

- **content/blog**: new post `2026-05-28-leaked-bam-memo.md` with schema-compliant frontmatter (`pubDate`, `heroImage`, `tags`, `description`) plus existing canonical/meta tags.

## Test Plan

- [x] `npm run dev` syncs content without schema errors and serves on http://localhost:4321/
- [x] Post renders at `/blog/2026-05-28-leaked-bam-memo/` with correct title, hero image, and date
- [x] Internal link to the May 25 post resolves
- [x] Post appears in the blog index and RSS feed