### PR TITLE
Add American Fork PD / Reckless Ben arrest post

### DIFF
--- a/src/content/blog/2026-05-30-bam-american-fork-pd.md
+++ b/src/content/blog/2026-05-30-bam-american-fork-pd.md
@@ -1,0 +1,119 @@
+---
+title: "Rubber Ducks, a Six-Figure LEGO Collection, and a Police Department Under the Spotlight"
+tags:
+  - bricks-and-minifigs
+  - lego
+  - star-wars
+  - oregon-law
+  - utah-law
+  - consignment
+  - elder-financial-abuse
+  - franchise-liability
+  - reckless-ben
+  - accountability
+  - true-crime
+description: >-
+  Two irreconcilable stories about the same arrest: a captured small-town police
+  department jailing a journalist for helping recover a stolen Star Wars LEGO
+  collection, or an LA content creator arrested after a multi-day harassment
+  campaign at a private home. A look at what the American Fork Police Department
+  record actually says about Reckless Ben's arrest, how the Oregon consignment
+  dispute migrated to Utah, and why accountability and transparency are the part
+  everyone is skipping.
+pubDate: '2026-05-30 14:45 -0500'
+updatedDate: '2026-05-30 15:07 -0500'
+heroImage: '/images/bam.webp'
+---
+
+There is a version of the Bricks & Minifigs story that fits neatly into a YouTube thumbnail: a small-town police department, allegedly captured by a powerful franchise, throws an investigative journalist in jail for the crime of helping an 83-year-old man recover his stolen Star Wars LEGO. There is another version, laid out by the American Fork Police Department, in which a Los Angeles content creator ran a multi-day harassment campaign against a private resident's home and got arrested for it.
+
+Both versions are circulating to audiences in the millions. Neither one, on its own, is the whole truth. Here is what is actually on the record, what is still just allegation, and why the part everyone is skipping — accountability and transparency — is the part that matters most.
+
+## How a LEGO consignment turned into a lawsuit
+
+The origin of all of this sits in Keizer, Oregon, not Utah.
+
+Bryan Mansell and his father spent roughly fifteen years assembling a Star Wars LEGO collection that was, at one point, described as one of the largest in the world, with a reported value north of $200,000. In November 2023, Mansell signed a formal consignment agreement with the operator of the Bricks & Minifigs Salem-Keizer location. Reporting on the agreement indicates the store would sell the collection and split proceeds — roughly 35% to the store, 65% to Mansell — while ownership of the unsold sets legally remained with Mansell until the moment of sale, and the store was obligated to insure the collection against loss.
+
+Then the franchise changed hands. In late 2024, control of the location shifted, and according to Mansell the new operators would not return the unsold inventory or honor the consignment arrangement. The former franchise operator, Chrystal Law (Gorman), has publicly claimed corporate effectively seized the store, denied her a chance to complete an inventory, and pushed her out under threat of police action.
+
+Bricks & Minifigs corporate tells it differently. CEO Ammon McNeff has said the prior operators carried significant unpaid obligations, that corporate terminated the franchise, that a third party handled the transition, and — critically — that consignment arrangements are not an authorized part of the franchise model. The company's position is that it was never a party to the Salem consignment deal and bears no responsibility for it, and it says the collection may already have been sold by the original operator before any of the current parties were involved.
+
+That is a genuine, unresolved civil dispute. Mansell reportedly won a default judgment in Oregon. The merits will be sorted out by courts and lawyers, not by a blog post or a video. Keep that firmly in mind, because almost everything that follows is *downstream* of people trying to resolve a business dispute through means that were never going to stay civil.
+
+## The dispute moves to Utah
+
+Enter Benjamin Schneider, 30, of Los Angeles — known online as "Reckless Ben." Schneider produced a series of investigation videos about the Mansell collection that have drawn millions of views, and he launched a GoFundMe that raised more than $10,000. By his account, he traveled to American Fork, Utah, to personally serve Joshua Johnson — an American Fork resident and Bricks & Minifigs employee — with civil papers in a follow-up lawsuit.
+
+What happened over four days in March is where the two narratives split hard.
+
+According to the day-by-day account American Fork Police Chief Cameron Paul released in a roughly 26-minute statement on May 29, Johnson called police on four separate occasions between March 8 and March 11 to report escalating conduct at his home. The department's version of events includes:
+
+- A staged delivery on March 8, in which a man wearing a cap with a UPS logo taped to it left a package of rubber ducks at Johnson's door. Police say Schneider later acknowledged the delivery was staged — designed to get Johnson to unknowingly sign a confirmation that Schneider allegedly intended to repurpose into a forged document.
+- A March 9 incident in which a man knocked on Johnson's door falsely claiming to have been sent by Johnson's church leader. Officers identified the man and say he acted at Schneider's direction.
+- A March 10 report from Johnson stating that, because of the ongoing harassment, he was at the point of threatening violence — a call officers responded to directly. (This is the encounter that has been recast online as police "swatting" Schneider's team at gunpoint.)
+- A March 11 sign hung across from Johnson's home depicting him as having robbed a dying man — after which Schneider was arrested a second time, this time at a nearby Airbnb on a search warrant approved by a Fourth District judge.
+
+Schneider faces misdemeanor charges: stalking, targeted residential picketing, disorderly conduct, and criminal trespass. A protective order was granted against him on May 20, the case remains active, and he has not entered a plea. Bricks & Minifigs, for its part, has filed a civil suit accusing Schneider, Mansell, and others of a harassment and extortion campaign.
+
+Chief Paul's framing of his department's role was blunt: their job was not to referee an Oregon business dispute, but to respond to conduct reported in their own jurisdiction and enforce Utah law. Believing you were financially wronged, in other words, does not suspend the laws on harassment and trespass.
+
+## The competing narrative
+
+Schneider and his supporters tell a very different story, and it is the one that went viral first.
+
+In that telling, the American Fork officers harassed him and his team, illegally redacted body-camera audio, jailed him in apparent retaliation for the GoFundMe, and left him facing up to five years in prison — to the point that he has claimed to have left the country. A streaming executive amplifying the case on social media has leaned heavily on the fact that the officers, the franchise's current operators, and the CEO are Latter-day Saints, framing American Fork as a "Mormon police department" protecting its own.
+
+Here is the part that requires intellectual honesty: as of this writing, those misconduct claims are **unproven and contested**. Outlets covering the saga have explicitly flagged the police-corruption allegations as unverified. The religious framing is an insinuation, not evidence — shared faith among the parties is not, by itself, proof of a conspiracy, and treating it as such is exactly the kind of leap that should make any careful reader uncomfortable.
+
+But the reverse is equally true. A 26-minute statement from a chief, narrated from his own officers' reports, is the department's case for the department's conduct. It is not the same thing as the underlying records. Detailed and persuasive as it may be, it is still the institution grading its own homework.
+
+## What's verifiable and what isn't
+
+Strip away both sides' framing and a few things are reasonably solid:
+
+- There was a real consignment agreement, a real franchise takeover, and a real, unresolved civil fight over a valuable collection.
+- Johnson repeatedly called police; Schneider was arrested twice; charges were filed; a protective order issued; civil suits are live.
+- A vehicle was stopped, a drug-dog sniff was conducted after a breath test reportedly came back at .00, and a vehicle search turned up nothing. A search warrant later added a hunt for stolen LEGO based on a third party's statement, and nothing was seized.
+
+What is *not* established: whether the stops and searches were legally justified or pretextual; whether body-camera footage was redacted improperly or lawfully; whether any charge was, in substance, a response to Schneider's protected speech and fundraising rather than to genuine harassment; and whether Schneider's own conduct crossed from aggressive civil-process service into criminal harassment. Those are precisely the questions a court — and, ideally, an independent review — exists to answer.
+
+## Why transparency is the whole ballgame
+
+This is where I have a stake, and where I think the public conversation is misfiring.
+
+The viral debate is stuck on a binary — *the cops are corrupt* versus *the YouTuber is a criminal* — when the actually answerable question is narrower and more important: **did the American Fork Police Department's specific decisions hold up to scrutiny, and will the department let anyone check?**
+
+I wrote to Chief Paul directly. I credited him for putting an account on the record, and then I asked for the things a statement can't substitute for:
+
+- The body-worn camera footage, released in full, with only legally required redactions and a clear statement of what was withheld and why.
+- The articulable basis for the K-9 sniff and vehicle search that produced nothing.
+- The corroboration behind a warrant that bolted on a stolen-LEGO search and seized nothing.
+- A plain statement of which specific acts each criminal charge rests on, so the public can separate enforcement of harassment and trespass law from any response to protected activity.
+
+And because the conduct of the department's own officers is what's in question, I urged that any review be conducted or audited externally rather than internally, with the findings made public. Self-investigation is not oversight.
+
+In Utah, the cleanest path to the footage and records isn't a polite request to the chief — it's a public records request under the Government Records Access and Management Act (GRAMA), which obligates the agency to respond. That request is the next thing I'm putting together, and I'd encourage anyone who actually cares about the answer rather than the dunk to do the same.
+
+## Where it stands
+
+The criminal case against Schneider is unresolved, and he is presumed innocent. The misconduct allegations against the American Fork officers are unproven, and they deserve a real, external look rather than either reflexive belief or reflexive dismissal. The underlying Oregon dispute — the thing that started all of this — is still grinding through the civil courts.
+
+If you take one thing from this mess, let it be this: a viral video is not an investigation, and a press statement is not an audit. The footage either supports the department's account or it doesn't. The way to find out is to demand the records and insist on independent eyes — and to be just as willing to follow the evidence if it exonerates the officers as if it doesn't.
+
+I'll be following this one, and I'll post what the records show.
+
+---
+
+### Sources & further reading
+
+- *American Fork Citizen* — "YouTuber arrested twice by AF police over LEGO dispute" (May 30, 2026)
+- Chief Cameron Paul's full department statement (American Fork Police, May 29, 2026)
+- *Salem Business Journal* — coverage of the Keizer consignment agreement and franchise dispute
+- *Statesman Journal* — reporting on the shuttered Keizer store and the theft accusation
+- *Dexerto* — overview of the lawsuits and viral investigation (notes police-corruption claims are unproven)
+- *Primetimer* — explainer on the dispute, the GoFundMe, and the social-media allegations
+- Wikipedia — "Bricks & Minifigs" (background and timeline)
+- Schneider's own YouTube videos (the creator's account of events)
+
+*Charges referenced here are allegations; Benjamin Schneider is presumed innocent unless proven guilty. Allegations of police misconduct are likewise unproven. This post is commentary and summary, not legal advice or a determination of fact.*


### PR DESCRIPTION
## Summary

- Adds a follow-up post in the Bricks & Minifigs series covering the arrest of Benjamin "Reckless Ben" Schneider in American Fork, Utah.
- Lays out the two irreconcilable public narratives — a "captured" police department vs. a multi-day harassment campaign at a private home — and separates record from allegation.
- Traces how the Oregon consignment dispute migrated to Utah and centers the accountability/transparency angle most coverage skips.

## Changes

- **content/blog**: new post `2026-05-30-bam-american-fork-pd.md` with schema-compliant frontmatter (`title`, `pubDate`, `updatedDate`, `heroImage`, `tags`, `description`).

## Test Plan

- [x] `npm run dev` syncs content with no schema errors
- [x] Post renders at `/blog/2026-05-30-bam-american-fork-pd/` (returns HTTP 200) with correct title, hero image, and date
- [x] Frontmatter parses cleanly (closing `---` present; no YAML errors in dev log)
- [x] Post appears in the blog index and RSS feed