### PR TITLE
Add Ammon McNeff / Legally Mine profile post

### DIFF
--- a/src/content/blog/2026-06-01-ammon-mcneff-legally-mine.md
+++ b/src/content/blog/2026-06-01-ammon-mcneff-legally-mine.md
@@ -1,0 +1,153 @@
+---
+title: "Ammon McNeff and Legally Mine - and why it matters"
+tags:
+  - bricks-and-minifigs
+  - lego
+  - star-wars
+  - oregon-law
+  - consignment
+  - elder-financial-abuse
+  - franchise-liability
+  - reckless-ben
+  - accountability
+  - true-crime
+description: >-
+  Before he was CEO of Bricks & Minifigs, Ammon McNeff was president of Legally Mine — a Utah outfit that, for a fee, teaches doctors and business owners how to make themselves
+  judgment-proof. A look at who McNeff is, what Legally Mine actually sells, the federal class action it litigated (Eliasieh v. Legally Mine), the BBB complaint record, and why an asset-protection background is uncomfortable context for a man whose company is accused of absorbing an 83-year-old's $200,000 Star Wars LEGO collection and hiding behind a corporate shield.
+pubDate: '2026-06-01 08:45 -0500'
+heroImage: '/images/bam.webp'
+---
+
+# The Asset-Protection Man — Who Ammon McNeff Is, What Legally Mine Sells, and Why It Matters to the Bricks & Minifigs Case
+
+Tony Guntharp · June 1, 2026
+
+*The fourth post in a series. See [How Bricks & Minifigs Allegedly Stole an Old Man's Star Wars LEGO Collection](https://fusion94.org/blog/2026-05-25-bricks-and-minifigs/) (May 25), [The Leaked Bricks & Minifigs Crisis Memo](https://fusion94.org/blog/2026-05-28-leaked-bam-memo/) (May 28), and [Rubber Ducks, a Six-Figure LEGO Collection, and a Police Department Under the Spotlight](https://fusion94.org/blog/2026-05-30-bam-american-fork-pd/) (May 30).*
+
+I've spent three posts on the *what* of the Mansell / Bricks & Minifigs case — the consignment agreement, the seizure, the removed stickers, the leaked crisis memo, the arrests in Utah. This post is about a *who*. Specifically, the man whose name appears at the top of every corporate statement in this story: **Ammon McNeff**, CEO of BAM Franchising, Inc.
+
+I want to be precise about why I'm writing this, because it would be easy to mistake it for a hit piece, and it isn't one. McNeff's professional background became relevant the moment he started issuing public statements built almost entirely on a single legal proposition — that a corporate parent can take physical control of a store's contents and then disclaim all responsibility for what happens to third-party property inside it. That argument didn't come from nowhere. Before he ran a LEGO franchise, McNeff spent years at the head of a company whose entire product is teaching people how to put their assets beyond the reach of the people they owe.
+
+That is not a crime. It is, in fact, a large and legal industry. But it is *context*, and in this particular case it is uncomfortable context. Let me lay it out, sourced and careful, and let you decide what to make of it.
+
+---
+
+## Part One: Who Ammon McNeff Is
+
+The public record on McNeff is consistent across several independent sources.
+
+He and his brother **Matt McNeff** acquired the Bricks & Minifigs franchise system in 2018, after operating a single franchise location in Utah, and moved the company's headquarters to Utah that same year. At the time of acquisition the chain had roughly 35 locations. By 2025, trade and business publications put the network at around 300 stores across the U.S. and Canada, following an aggressive expansion run. McNeff has been CEO throughout; newer coverage names Matt McNeff as COO.
+
+That's the LEGO half of the résumé. The other half is the one I want to focus on.
+
+According to his own professional profiles and multiple business directories, before and around his B&M tenure McNeff served as **President of Legally Mine, LLC**, and as **Executive Director of the National Foundation for Asset Protection**. Legally Mine is a family business — the Better Business Bureau profile lists **Daniel J. McNeff** as CEO — headquartered in Orem/Provo, Utah, the same corner of Utah County where BAM is based and where the events of my [last post](https://fusion94.org/blog/2026-05-30-bam-american-fork-pd/) (the American Fork arrests) took place.
+
+So the man at the center of a dispute over who is responsible when property gets absorbed and sold off spent a chunk of his career as the public face of a company built to make sure property *can't* be reached. Hold that thought.
+
+---
+
+## Part Two: What Legally Mine Actually Sells
+
+Here's where I have to be careful to describe the company accurately rather than caricature it, because asset protection is a legitimate field and plenty of honest lawyers practice it.
+
+By its own marketing, Legally Mine provides "specialized legal entity documents and entity structuring strategies" to help medical, dental, and business professionals "protect themselves from the dangers of lawsuits." The pitch, repeated across its site and LinkedIn, is that the average business faces multiple lawsuits over its lifetime, and that the solution is to restructure how you *own* things — moving assets into LLCs, family limited partnerships (frequently domiciled in debtor-friendly states like Utah and Alaska), holding companies, and trusts — so that there's legal separation between you and what you own. The stated goal, in the industry's own shorthand, is to make a client **"judgment proof"**: when a creditor wins, there's nothing collectible left to reach.
+
+The company markets heavily through professional conferences and continuing-education seminars. It advertises that it provides CE credits across professions and even CLE credits for attorneys. This is a recognized go-to-market motion in the space — you get in front of a room full of doctors, scare them about malpractice exposure, and sell packages on the way out.
+
+Two things are worth flagging for anyone evaluating the company, both drawn from the public record rather than my opinion:
+
+**It is not a law firm.** This is the most persistent third-party critique. A long-running discussion on the Bogleheads investing forum — where a professional described taking a Legally Mine CE course — concluded that the company appears to sell access to a library of asset-protection documents rather than practice law, and was skeptical of some of the tax angles pitched (for example, the §280A "rent your home to your own entity up to 14 days a year tax-free" maneuver). Skepticism on a forum isn't proof of anything, but the "is this legal services or a document mill?" question is one that has followed the company for years.
+
+**The complaint record is mixed-to-rough.** The BBB profile for Legally Mine carries a body of complaints. The themes that recur in them: clients paying substantial sums — figures of **$6,800 and $8,000** appear in published complaints — for asset-protection-and-tax packages; a "you'll save more in taxes than you paid us or get a full refund" guarantee that clients say didn't pan out; entities that generated ongoing costs (state privilege taxes, monthly service fees) without delivering the promised benefit; and communication going dark after the upfront fee cleared. I'm summarizing the pattern, not endorsing any single complaint as adjudicated fact — BBB complaints are one-sided by nature. But the volume and consistency are part of the public picture.
+
+---
+
+## Part Three: The Federal Class Action — *Eliasieh v. Legally Mine*
+
+Legally Mine has also been a defendant in federal court, and the case is instructive about how the company operates when challenged.
+
+In **Eliasieh v. Legally Mine, LLC**, No. 3:18-cv-03622 (N.D. Cal.), a physician named Kasra Eliasieh filed a putative **class action** against the company. The docket and the published orders from Magistrate Judge Jacqueline Scott Corley tell a story with a few notable beats:
+
+- Legally Mine obtained a 45-day extension to respond, ostensibly for settlement discussions, then **missed the responsive-pleading deadline**. The plaintiff obtained an entry of default and moved for default judgment.
+- On the same day the plaintiff moved for default judgment, Legally Mine moved to **set aside the default**. The court granted that motion and denied default judgment as moot — meaning the company got a second bite rather than losing by default.
+- Legally Mine then moved to **compel arbitration** and stay the case, attaching a declaration from **Ammon McNeff** in support. The court ruled on the arbitration motion in 2019, and litigation over lifting the stay, attorney's fees, and an amended complaint continued into 2020. A related second case was later filed.
+
+I'm not going to overstate what this proves. A class-action defendant moving to compel arbitration is utterly routine — arbitration clauses are exactly the kind of contractual armor an asset-protection company would itself recommend. But there is a tidy irony in watching a company that sells "protect yourself from lawsuits" find itself on the receiving end of one, and respond by deploying the standard lawsuit-deflection toolkit: missed deadlines papered over, default set aside, dispute shunted into private arbitration and away from a public courtroom and a class. The relevant signature here — *Ammon McNeff, declarant* — is the same name on the BAM statements.
+
+---
+
+## Part Four: Why Any of This Matters to the LEGO Case
+
+Now the part that actually connects to the Mansell story, and where I want to stay disciplined about the line between *fair inference* and *unfair leap*.
+
+**The unfair leap, which I am not making:** there is no evidence that Legally Mine was involved in the Bricks & Minifigs seizure, that any Legally Mine structure was used to hide the Mansell collection, or that the LEGO dispute is some kind of asset-protection scheme. I have seen nothing of the sort, and I'm not insinuating it. If you came here for that, you'll be disappointed.
+
+**The fair inference, which I think is legitimate:** the entire public defense BAM has mounted in this case is, structurally, an asset-protection argument. Walk back through what corporate has actually said, as documented by the *Salem Business Journal* and BAM's own May 21 blog post:
+
+- *"This particular situation involves a single independently owned and operated franchise location."* — A separation-of-entities argument. The harm happened over *there*, in a different legal box, not here at corporate.
+- *"BAM Franchising, Inc. was not a party to this alleged agreement … the company was not party to the unauthorized Salem consignment agreement and bears no responsibility for obligations arising from it."* — A no-privity argument. You can't reach us; we're not on the contract.
+- The leaked crisis memo's reported instruction to franchisees to recite that each store is *"separate and independently owned, with no information to share"* — the same separation principle, pushed down to a script for teenagers at the register.
+
+This is the franchise-liability shield I took apart in the [first](https://fusion94.org/blog/2026-05-25-bricks-and-minifigs/) and [second](https://fusion94.org/blog/2026-05-28-leaked-bam-memo/) posts using *Viado v. Domino's Pizza*, 230 Or. App. 531 (2009), and *Miller v. McDonald's Corp.*, 150 Or. App. 274 (1997). The legal test in those cases is **control**: a franchisor loses the independent-contractor shield when it controls "the specific part of its business that allegedly resulted in plaintiff's injuries." And per the *Salem Business Journal's* reporting, BAM didn't merely set standards and walk away — corporate sent a representative to physically seize the Keizer store, took control of its inventory, engaged Baker Bricks LLC to inventory it, and then sold the store and contents to that same entity. Every operative act was corporate's.
+
+Here's the throughline worth naming. Asset protection, done legitimately, is about building walls *before* trouble arrives — separating your house and your savings from your business so a future plaintiff can't reach across the line. What is alleged in the Mansell case is something the field's ethics would not endorse and its better practitioners explicitly warn against: not building a wall around *your own* assets in advance, but using corporate separateness *after the fact* to disclaim responsibility for *someone else's* property that your company took into its possession. The first is estate planning. The second, if a court finds the control and the knowledge were there, starts to look like the **conversion** claim the Gormans have already pleaded — *Mustola v. Toddy*, 253 Or 658 (1969) — and potentially the elder-financial-abuse exposure under **ORS 124.100**, with its treble damages, given that the elder Mr. Mansell is 83.
+
+A man who spent years teaching clients exactly where the line is between legitimate separation and fraudulent transfer is not a man who can credibly claim he doesn't understand the distinction. That's the relevance. Not guilt by association — *sophistication* by background. When BAM's defense leans this hard on entity separation, it's worth knowing that the person directing the defense has a professional fluency in precisely that argument.
+
+---
+
+## Part Five: The Knowledge Problem, Revisited
+
+There's a second reason the background matters, and it goes to the single most important factual dispute in the whole case: **what corporate knew, and when.**
+
+Recall from the *Salem Business Journal's* reporting: the Gormans allege that on the night of the November 14, 2024 seizure, BAM's own then-Director of Operations, **Ki McAllister**, was on speakerphone, was told about the Mansell consignment, and *acknowledged it* — stating the new operator would take over the consignment too. The Gormans say the store's security camera captured this, and that the footage is now with the Keizer Police Department. McNeff has declined to address the contents of that video, citing litigation, while maintaining corporate had no knowledge of the consignment at the time.
+
+If that footage shows what the Gormans say it shows, then corporate's "we didn't know" position collapses, and with it the innocent-mistake framing. Knowledge is the hinge between a sloppy franchise transition and the *intent* element that Oregon's theft-by-deception statute (**ORS 164.085**) requires. It is the difference between "we accidentally swept up some consigned inventory" and "we were told on video whose property it was and sold it anyway."
+
+I raise McNeff's asset-protection background here not to assume the worst, but because it sharpens the stakes of that evidentiary question. This is not a naïve operator who stumbled into a legal gray area. This is, by his own résumé, someone who built a career on the granular mechanics of ownership, title, and creditor reach. The "we didn't understand the consignment created a third-party claim" defense is a harder sell from a former asset-protection executive than it would be from almost anyone else. A jury is allowed to weigh that.
+
+---
+
+## Part Six: What Would Actually Resolve This
+
+I've ended every post in this series the same way, and I'm not going to break the pattern, because it remains true.
+
+None of the above — not the asset-protection background, not the BBB complaints, not the *Eliasieh* docket — establishes that Ammon McNeff or BAM Franchising did anything illegal in the Mansell matter. Those are allegations, the criminal investigation has not produced charges as of this writing, and the civil suits are unadjudicated. McNeff is entitled to the presumption of innocence and to mount whatever lawful defense he chooses, including the entity-separation defense his background makes him good at.
+
+But the simplest path off the front page has never changed, and it has nothing to do with scripts, restraining orders, or which legal box the liability lands in. It is the thing a genuinely uninvolved corporate parent could do tomorrow without admitting a thing: locate the remaining sets, return them, or pay the family what the collection was worth. An 83-year-old man and his son spent fifteen years and $30,000 building something for the next generation. The collection is valued at $150,000 to $200,000. BAM did roughly $200,000 in claimed offsets in the seizure. The numbers are not unbridgeable.
+
+A company whose leadership spent years counseling others on how to protect what's *theirs* could, in this one instance, choose to protect what was someone *else's*. That would be the more interesting headline. I'd write that one happily.
+
+I still hope Bryan Mansell gets what he's owed.
+
+---
+
+## A Note on Sourcing and Fairness
+
+Everything above about Legally Mine and Ammon McNeff is drawn from public sources: the company's own website and LinkedIn, the Better Business Bureau profile and complaint record, the federal court docket in *Eliasieh v. Legally Mine, LLC* (N.D. Cal.), business directories listing McNeff's roles, the *Salem Business Journal's* primary-source investigation, and the corporate and Wikipedia records on Bricks & Minifigs. I reached no conclusion about the *legality* of Legally Mine's products — asset protection is a lawful field — and I've tried to flag, every time, the difference between what's documented and what's alleged. If anyone connected to Legally Mine, the National Foundation for Asset Protection, or BAM Franchising believes I've gotten a fact wrong, my contact information is on this site and I will correct the record.
+
+---
+
+## Sources and Further Reading
+
+- [Salem Business Journal: "Local Family's Lego Collection Caught in Keizer Franchise Fight, Criminal Investigation"](https://salembusinessjournal.org/2026/03/30/keizer-lego-dispute-star-wars-collection/) — *Jesse Peone; the definitive primary-source report.*
+- [Primetimer: "Who is Ammon McNeff? Bricks and Minifigs CEO comes under fire"](https://www.primetimer.com/features/who-is-ammon-mcneff-bricks-and-minifigs-ceo-comes-under-fire-as-reckless-ben-patreon-lego-controversy-intensifies)
+- [The Org: Ammon McNeff profile (CEO, B&M North America; President, Legally Mine; Exec. Director, National Foundation for Asset Protection)](https://theorg.com/org/bricks-minifigs-north-america/org-chart/ammon-mcneff)
+- [Legally Mine — Company Overview](https://legallymine.com/company/) and [Asset Protection](https://legallymine.com/asset-protection/)
+- [Legally Mine — LinkedIn company page](https://www.linkedin.com/company/legally-mine-llc)
+- [Better Business Bureau — Legally Mine, LLC profile](https://www.bbb.org/us/ut/orem/profile/legal-services/legally-mine-1166-22270989) and [complaints](https://www.bbb.org/us/ut/orem/profile/business-plan/legally-mine-llc-1166-22270989/complaints)
+- [Bogleheads forum discussion: "Legally Mine [Asset Protection Law Firm]"](https://www.bogleheads.org/forum/viewtopic.php?t=114671)
+- [CourtListener docket: Eliasieh v. Legally Mine, LLC, 3:18-cv-03622 (N.D. Cal.)](https://www.courtlistener.com/docket/7199251/eliasieh-v-legally-mine-llc/)
+- [Casemine: Eliasieh v. Legally Mine — Order Granting Motion to Set Aside Default](https://www.casemine.com/judgement/us/5c40019e342cca1a0b07ee6c)
+- [Wikipedia: Bricks & Minifigs](https://en.wikipedia.org/wiki/Bricks_&_Minifigs)
+- [The Express Tribune: BAM CEO Ammon McNeff addresses $200K LEGO dispute](https://tribune.com.pk/story/2610668/bricks-and-minifigs-ceo-ammon-mcneff-addresses-200k-lego-dispute-in-lengthy-interview)
+
+*(For the underlying theft, conversion, elder-abuse, franchise-liability, and anti-SLAPP authorities — ORS 164.085, 164.095, 164.057, 164.061, 124.100, 31.150; Mustola v. Toddy; Viado v. Domino's; Miller v. McDonald's — see the [first](https://fusion94.org/blog/2026-05-25-bricks-and-minifigs/) and [second](https://fusion94.org/blog/2026-05-28-leaked-bam-memo/) posts in this series.)*
+
+---
+
+*Tony Guntharp writes at fusion94.org about technology, open source, and the things that matter. He is also a LEGO collector and knows exactly how much those Star Wars sets are worth.*
+
+---
+
+*Disclaimer: This article is journalistic commentary based on publicly available reporting, court records, and corporate and consumer-protection filings. Nothing herein constitutes legal advice, and nothing herein asserts that Ammon McNeff, Legally Mine, LLC, the National Foundation for Asset Protection, or BAM Franchising, Inc. has committed any crime. Asset protection is a lawful field of practice. All allegations relating to the Mansell / Bricks & Minifigs matter remain unproven in court. Readers seeking legal guidance should consult a licensed attorney.*


### PR DESCRIPTION
## Summary

- Adds the fourth post in the Bricks & Minifigs series, profiling BAM CEO Ammon McNeff and his prior role as president of Legally Mine.
- Argues that an asset-protection background is relevant context for the company's "corporate shield" / independent-franchisee defense.
- Grounds the piece in the public record — the Eliasieh v. Legally Mine federal class action and the BBB complaint history — rather than speculation.

## Changes

- **content/blog**: new post `2026-06-01-ammon-mcneff-legally-mine.md` with schema-compliant frontmatter (`title`, `pubDate`, `heroImage`, `tags`, `description`).

## Test Plan

- [x] `npm run dev` syncs content with no schema errors
- [x] Post renders at `/blog/2026-06-01-ammon-mcneff-legally-mine/` (returns HTTP 200) with correct title, hero image, and date
- [x] Series cross-links to the May 25 / 28 / 30 posts resolve
- [x] Post appears in the blog index and RSS feed