### PR TITLE
Add BAM Salem press release blame-shift analysis

### DIFF
--- a/src/content/blog/2026-06-05-bam-salem-press-release-blame-shift.md
+++ b/src/content/blog/2026-06-05-bam-salem-press-release-blame-shift.md
@@ -1,0 +1,125 @@
+---
+title: "A 'Devastating Social Media Campaign': BAM's Salem Press Release Is a Blame-Shift"
+pubDate: '2026-06-05 06:45 -0500'
+author: Tony Guntharp
+categories:
+  - Investigations
+  - Bricks & Minifigs
+tags:
+  - Bricks & Minifigs
+  - BAM Franchising
+  - Salem
+  - Keizer
+  - Mansell
+  - franchise accountability
+  - consumer protection
+description: "BAM's June 4 press release announces a 'mutual agreement to part ways' with its Salem franchise owners and pins the blame on a former franchisee. Read closely, it reads less like an accounting and more like a deflection — and its companion timeline makes the seams show."
+heroImage: '/images/bam.webp'
+---
+
+# A "Devastating Social Media Campaign": BAM's Salem Press Release Is a Blame-Shift
+
+On June 4, 2026, Bricks & Minifigs corporate published a press release announcing the permanent closure of its Salem, Oregon store and a "mutual agreement to part ways" with franchise owners **Brandon Best** and **Joshua Johnson**. The same day, it published a companion piece — a self-described timeline titled *What We Presently Believe Actually Happened*. Both are dated Salt Lake City, bylined to the company's "marketingteam," and filed, fittingly, under *Uncategorized*.
+
+They are worth reading together and carefully, because beneath the corporate cadence they do three things at once: they recast a documented business dispute as a public-relations injury, they relocate blame onto a departed former franchisee, and they give both the current owners and corporate itself a clean exit. None of those framing choices is illegal. All of them are choices. This post is about the choices — and about the places where the two documents, read side by side, don't hold together.
+
+As always: everything that follows is commentary on public statements and on prior reporting. Allegations described here — by all parties — remain allegations. Nothing here is legal advice.
+
+## "Due to a devastating social media campaign"
+
+Start with the stated reason for the split. The release attributes the parting with Best and Johnson, and the store's closure, to a "devastating social media campaign." The companion timeline says the same thing in plainer words: the store was "forced" to close because of an online disparagement campaign.
+
+Read that again. The official explanation for why two franchise owners are leaving and a store is closing is *the existence of public attention.* Not the underlying conduct that generated the attention. Not the consignment that was allegedly sold out from under its owner. Not the identifying stickers that, per prior reporting, were removed from a collector's sets before they were resold. The framing is that the problem is the campaign, not the thing the campaign is about.
+
+This is the single most revealing line in the document. When an organization names "the social media campaign" as the cause of a separation, it is telling you what it considers the injury. The injury, in this telling, is being talked about.
+
+What the release conspicuously does **not** do is account for anything Best and Johnson did during their ownership. Recall what is already on the record from the *Salem Business Journal* reporting and the Mansell account documented in this series:
+
+- The new operators **denied any knowledge** of the consignment arrangement when Bryan Mansell came to recover his collection.
+- After they claimed Mansell's sets had been removed from the store, Mansell sent a buyer in — and that buyer **successfully purchased one of his consigned sets**, with the yellow-dot identifying sticker peeled off the UPC barcode.
+- Mansell's **November 22, 2024 written termination notice** went to Brandon Best at the Keizer address, citing a missed installment and a refusal to allow inspection on November 21, 2024.
+- The entity that conducted the post-seizure inventory *on corporate's behalf* — Baker Bricks LLC — then **bought the store** roughly a month later, with Best and Johnson installed as operators.
+
+That is the conduct a candid statement would address. Instead, the conduct is absent and "the social media campaign" is present. The release manages to announce that Best and Johnson are leaving without once describing what they are leaving over. That is not an accounting. It is a euphemism with a press dateline.
+
+## The pivot to Chrystal Law-Gorman
+
+If the social-media framing tells you what BAM considers the injury, the body of both documents tells you who BAM has decided will carry it. The answer is the former franchisee, **Chrystal Law-Gorman.**
+
+The structure is unmistakable. The headline is about Best and Johnson. The substance is almost entirely about Law-Gorman. She is the one accused — in a corporate press release, by name — of maintaining "three sets of books," of a "hidden personal bookkeeping version," of an "unauthorized" consignment she allegedly never disclosed, and of owing close to $200,000 at the time of separation. The release reaches for her partner's overseas job offer, a personal detail with no bearing on the consignment that exists in the text only to color the picture. The timeline goes further, describing her on the night of the handover as removing cash from the till, refusing to surrender keys, and making repeated trips to her car.
+
+Set aside, for a moment, whether any of that is true — it is unproven, and Law-Gorman has her own account of being pushed out under threat of police action, denied the chance to complete an inventory, and not even permitted to keep a copy of the spreadsheet she had been maintaining. Focus instead on the *function* of the accusations within the document. Every charge against Law-Gorman performs the same job: it moves responsibility backward in time, to a person who is no longer there, for events that allegedly "predated" the current owners. The current owners become unwitting inheritors. Corporate becomes the diligent party that "finally" assembled the picture. And the named former franchisee becomes the load-bearing scapegoat for all of it.
+
+## The "unauthorized side deal" runs into its own facts
+
+The recurring theme across BAM's posts is that the consignment was a purely personal, "unauthorized" side deal that corporate knew nothing about. But the company's own timeline supplies the facts that complicate that claim.
+
+By BAM's own account, the November 2023 public unveiling of the Mansell collection was promoted on the store's **official Facebook page**, and the press contact listed was **salem@bricksandminifigs.com** — a corporate-domain email address. The 83-year-old Eric Mansell was photographed with the operator at a public event held *in the store.* A collector who saw a BAM-branded store, dealing with the BAM operator, promoting the arrangement on the official BAM store page using a BAM email, had every reason to believe he was dealing with Bricks & Minifigs.
+
+Whether a franchisor can disclaim a brand-fronted store's conduct by labeling the operator "unauthorized" is exactly the apparent-authority question that *Miller v. McDonald's Corp.* and *Viado v. Domino's Pizza* exist to test. The press release asserts the firewall. Its own timeline hands you the facts that test it.
+
+There is a second wrinkle. BAM's timeline states that Law-Gorman's insolvency "trigger[ed] BAM Corporate's security interest in the inventory." Read that carefully: corporate is asserting a **security interest in the store's inventory** as the basis for taking control. But consigned goods are not the store's property to pledge as collateral — title to the unsold sets remained with Mansell until sale, per the consignment terms documented in this series. If corporate swept the store's inventory under a security interest, the obvious question is whether that sweep included property that was never the franchisee's to encumber. The timeline raises the question and does not answer it.
+
+## The sticker problem
+
+Here is where the two BAM documents collide most directly with the documented record.
+
+The timeline says that in late November or December 2024, Best and Johnson discovered roughly 25 Star Wars sets in a closed back closet, "did not think anything of" the small stickers on them, kept them segregated, and offered them to Mansell out of sympathy. The same document says that when Josh walked Mansell through the store, Mansell "could not identify any of his collection on display."
+
+Of course he couldn't — by BAM's own telling, the sets were in a closet, not on display. The framing presents Mansell's inability to spot his collection as exculpatory, while the same paragraph explains exactly why he couldn't see it.
+
+Now hold that against two things already on the record. First, Law-Gorman's photographs from the night of November 14, 2024 — timestamped roughly 7:50 to 7:55 p.m. — reportedly show Star Wars sets bearing the yellow-dot identifying stickers still **on the store shelves**, not sequestered in a closet. Second, after the new operators told Mansell his sets were gone, the buyer he sent in **purchased one of those consigned sets with the sticker removed from the UPC.** BAM's "we kept the stickered sets carefully segregated and offered them back" cannot easily coexist with "a stickered-then-unstickered set was sold off the floor." Both accounts cannot be complete. The contradiction is not in my framing; it is between BAM's timeline and the documented record.
+
+## The math BAM published
+
+The timeline contains a set of numbers that, taken together, undercut the document's own thesis.
+
+By BAM's account, Mansell received approximately **$15,000** in total payouts over roughly a year. Also by BAM's account, its internal POS data shows at least **$52,000 — "and likely more"** — was sold from the collection during Law-Gorman's tenure. Under the consignment split documented in this series (roughly 65% to Mansell), $52,000 in sales should have produced on the order of **$33,000+** for Mansell. He got $15,000. So even using BAM's own figures, Mansell was underpaid by something like $18,000 — before accounting for "likely more" — and before accounting for whatever happened to the collection *after* Law-Gorman left and the store passed through a corporate-directed inventory into the hands of Best and Johnson.
+
+That last point is the one BAM's arithmetic never closes. The company offers a detailed accounting of what allegedly went wrong while Law-Gorman ran the store, and near silence about what happened to the remaining collection once corporate controlled the premises, the POS, and the transition. The $52,000 figure is presented as Law-Gorman's malfeasance. But the POS that recorded it was BAM's system, and it kept recording after she was gone.
+
+## The valuation reframe, and the number that undercuts it
+
+Both documents try to deflate the figure that has driven public sympathy. The widely circulated **$200,000** value is recast as a mere "promotional" figure used to hype a 2023 viewing event, with the "real" value pegged at **$95,000 to $100,000** and anchored, pointedly, to Mansell's own podcast statement and an ~$80,000 ask.
+
+As pure messaging, that is a clean move: cut the perceived loss roughly in half, and source the lower number to the collector's own mouth. But it collides with the company's other claims. The same timeline describes a collection of over 780 sealed sets and 1,200 minifigures, with at least one set valued above $10,000 and individual minifigures estimated above $1,300 each. A $95,000–$100,000 ceiling on 780 sealed sets plus 1,200 minifigures — some of them four-figure pieces individually — is a number that needs defending, not just asserting. And if BAM's own POS shows $52,000-plus "and likely more" already sold, then the *unaccounted* exposure is most of the collection. The release deploys a number meant to shrink the story and, in the same breath, supplies numbers that enlarge it.
+
+Note too the evidentiary double standard. Mansell and Law-Gorman are faulted for not producing "formal documentation" and a "signed copy" of the agreement. BAM, meanwhile, asserts its own conclusions — three sets of books, a secret email account, the $52,000 figure, the revised valuation — from data it characterizes but does not show. One side is held to signed originals; the other narrates.
+
+## Sourced to "BAM team"
+
+The timeline footnotes its sources entry by entry, and the pattern of attribution is itself revealing. The claims that are independently checkable — the public Facebook posts, the April 2025 podcast, the dated display event — are sourced to those external records. But the claims that matter most to BAM's defense, and that no outsider can verify, are sourced to "BAM team" or to "BAM June 4, 2026 Announcement" — that is, to BAM itself.
+
+The insolvency figure, the claim that Law-Gorman said nothing about a consignment in October or on November 8, the private November 8 agreement not to pursue the full $200,000, the handover-night narrative, the closet discovery: these load-bearing entries rest on the company's own say-so, presented in a document whose header promises "every entry is attributed to a verifiable source." Attributing a contested claim to yourself does not make it verifiable. It makes it a statement.
+
+## The temporary restraining order
+
+The timeline notes that on May 28, 2026, a Utah court issued a temporary restraining order requiring that the videos BAM characterizes as defamatory be taken down. BAM presents this as vindication.
+
+It is worth flagging what a TRO ordering the removal of speech actually is in First Amendment terms: a **prior restraint**, the most disfavored form of speech regulation American law recognizes. As this series has discussed before in connection with Oregon's anti-SLAPP statute (ORS 31.150) and the prior-restraint doctrine, an order compelling the takedown of allegedly defamatory commentary before any final adjudication on the merits sits on constitutionally shaky ground. A TRO reflects a court's preliminary view on likelihood of success and irreparable harm; it is not a finding that the speech was false. BAM is entitled to pursue its legal remedies. But a takedown order is not the same thing as a ruling that the underlying reporting was wrong, and presenting it as a settled verdict on the truth is exactly the kind of overclaim a careful reader should resist.
+
+## Settlement by press release
+
+Layered on top is CEO Ammon McNeff's public overture to Mansell: a "we're ready when you are, let's go through the spreadsheets" invitation to sit down, be "made whole," take whatever Star Wars LEGO remains "whether you identify as yours or not," and — quietly — discuss dropping the lawsuit against him. The timeline frames this as a willingness to "potentially dismiss Bryan personally as a named defendant" in BAM's litigation.
+
+Real settlement happens through counsel, not through a press release written in the second person. An offer published this way is aimed at the audience, not the counterparty; it is meant to be *seen* extending an olive branch. And buried in the gesture is a fact the warm tone is designed to soften: BAM named the collector as a defendant in its own lawsuit, and is now publicly offering to *un-name* him as an inducement to sit down. The "$350K GoFundMe" line dropped into the key-details list, uncommented, does similar work — it invites the reader to conclude the public over-gave relative to the "true" value. The number is left to do the insinuating.
+
+## Two posts, several contradictions
+
+Published the same hour, the two documents don't even agree with each other. The press release says the consignment was made "in November 2023"; the timeline's own section header dates it to "October 2023" before the body says November. The press release says BAM offered Mansell the inventory "most recently in December 2025"; the timeline places that offer in December 2024. The podcast that anchors the valuation claim is called "Collecting Weekly" in one post and "Collectors Weekly" in the other. The subhead misspells Mansell's first name as "Brian" while the body uses "Bryan." Individually these are small. Collectively, in a document carrying serious accusations against a named private individual and published under a marketing byline in an *Uncategorized* blog, they signal how little legal and editorial care went into statements that create real exposure.
+
+## What a candid statement would have said
+
+It is worth being concrete about the gap. A genuine accounting of a parting with Best and Johnson would have addressed the denial of knowledge of the consignment, the resold sets with the stickers removed, the timeline by which the corporate-retained inventory firm became the store's buyer, corporate's own possession of the POS data throughout, and what became of the collection after corporate took control of the store. A genuine statement would have named the conduct it was separating over.
+
+These documents do none of that. They name a campaign as the injury and a departed franchisee as the cause. The current owners and corporate are the only parties who emerge without a description of what they did. That is the definition of a deflection: the actors most able to answer the open questions are the ones the documents decline to question.
+
+## The bottom line
+
+Strip the dateline and the boilerplate and the Salem press release is a liability-transfer exercise. The brand is the victim of an internet narrative. The mess belongs to a former franchisee. The current owners inherited it. And the collector, generously, is invited to settle — through a blog post.
+
+The most useful things in the two documents are the parts that escaped the messaging: the confirmation that BAM named Mansell as a defendant, the admission that $52,000-plus of his collection moved through BAM's own POS, the math showing he was underpaid even on BAM's own figures, the corporate email and official store page that complicate the "unauthorized side deal" frame, and the implicit concession that corporate held the transaction data all along. Those are not the points the documents wanted to make. They are the points worth remembering.
+
+---
+
+*This post is commentary on public corporate statements and on prior reporting, including the* Salem Business Journal *and* Kotaku*. Allegations by all parties — BAM, the former franchisee, the current owners, Mr. Schneider, and Mr. Mansell — remain unproven unless and until established in court. Nothing here constitutes legal advice. Corrections and documentation are welcome at fusion94.org.*


### PR DESCRIPTION
## Summary

- Adds an investigative commentary post analyzing Bricks & Minifigs corporate's June 4, 2026 Salem press release and its companion timeline.
- Examines how the documents recast a documented business dispute as a social-media injury and shift blame onto a departed former franchisee.
- Documents internal contradictions between the two BAM posts and against the prior record covered in this series.

## Changes

- **content/blog**: New post `2026-06-05-bam-salem-press-release-blame-shift.md` covering the "devastating social media campaign" framing, the pivot to the former franchisee, the consignment/"unauthorized side deal" question, the sticker contradiction, BAM's own published math, the valuation reframe, the TRO/prior-restraint angle, and settlement-by-press-release.

## Test Plan

- [x] `npm run dev` and confirm the post renders at its slug
- [x] Frontmatter validates (title, pubDate, author, categories, tags, description, heroImage)
- [x] `npm run build` completes without content-collection errors
- [x] Hero image `/images/bam.webp` resolves
