### PR TITLE
Add annotated timeline of the BAM Salem case

### DIFF
--- a/src/content/blog/2026-06-05-bam-salem-annotated-timeline.md
+++ b/src/content/blog/2026-06-05-bam-salem-annotated-timeline.md
@@ -1,0 +1,169 @@
+---
+title: "What the Record Actually Shows: An Annotated Timeline of the Bricks & Minifigs Salem Case"
+pubDate: '2026-06-05 07:45 -0500'
+author: Tony Guntharp
+categories:
+  - Investigations
+  - Bricks & Minifigs
+tags:
+  - Bricks & Minifigs
+  - BAM Franchising
+  - Salem
+  - Keizer
+  - Mansell
+  - timeline
+  - franchise accountability
+description: "BAM published its own timeline titled 'What We Presently Believe Actually Happened.' Here is the same chronology with the sourcing checked, the self-attributed claims flagged, and the documented record placed next to the company's version."
+heroImage: '/images/bam.webp'
+---
+
+# What the Record Actually Shows: An Annotated Timeline of the Bricks & Minifigs Salem Case
+
+On June 4, 2026, Bricks & Minifigs corporate published a timeline titled *What We Presently Believe Actually Happened.* Its header promises that "every entry is attributed to a verifiable source." That is a useful standard to take the company at its word on — so this post walks the same chronology and checks it.
+
+For each phase I lay out what is **established** (documented in independent reporting, public posts, court records, or admitted by multiple parties), what is **BAM's claim** (asserted in its own posts, often sourced only to "BAM team"), and what remains **contested or open**. Where BAM's version conflicts with the documented record, I say so plainly. Where it is simply unverifiable, I say that too.
+
+A note on method: a timeline is only as good as its sourcing. BAM's footnotes its entries, and the pattern matters. The independently checkable items — public Facebook posts, the April 2025 podcast, the dated display event — are sourced to those records. The load-bearing items in BAM's defense — the insolvency, the private agreements, the handover-night narrative, the closet discovery — are sourced to "BAM team." Attributing a contested claim to yourself does not make it verifiable; it makes it a statement. I have flagged those throughout.
+
+As always: allegations by all parties remain allegations unless and until established in court. Nothing here is legal advice.
+
+---
+
+## 2009–2018 — The franchise and its model
+
+**Established.** Bricks & Minifigs was founded in 2009 in Battle Ground, Washington; a second store opened in Canby, Oregon in 2010; franchising began in 2011. In 2018, brothers Ammon McNeff (CEO) and Matt McNeff (COO) joined BAM Franchising, Inc., and the brand grew from roughly 35 to more than 300 locations.
+
+**BAM's claim.** The business model is strictly Buy, Sell, Trade; consignment has never been authorized under the franchise agreement or operations manual, and no franchisee was ever permitted to enter a third-party consignment on BAM's behalf.
+
+**Open.** The "never authorized" assertion is central to BAM's no-liability defense. It is a statement about internal policy, not an independently verified fact, and — as discussed below — it sits uneasily next to BAM's own description of how the Mansell consignment was publicly promoted using corporate channels.
+
+---
+
+## Early 1990s–2023 — The Mansell collection is built
+
+**Established.** Eric Mansell spent years acquiring Star Wars LEGO sets, holding them as a long-term investment. His son Bryan took over the effort to sell when Eric decided it was time. Around September 2023, Bryan approached the Salem-Keizer Bricks & Minifigs store and its operator, Chrystal Law-Gorman, for help. By BAM's account the collection comprised over 780 sealed sets and 1,200 minifigures, including at least one set valued above $10,000 and individual minifigures estimated above $1,300.
+
+**BAM's claim.** The widely circulated **$200,000** figure was merely a "promotional" number used to generate excitement for a public display, and "both parties' own records" place the realistic high-end value at **$95,000–$100,000.**
+
+**Contested.** The valuation is one of the central disputes. BAM's own description — 780 sealed sets, 1,200 minifigures, four-figure individual pieces — is hard to reconcile with a $95,000–$100,000 ceiling, and the lower figure is asserted rather than shown. Bryan has stated a figure in that range publicly; whether that reflects the full collection's value or a conservative estimate is exactly what documentation, not a press release, would settle.
+
+---
+
+## September–November 2023 — Trial run, agreement, and public unveiling
+
+**Established.** In September 2023, Law-Gorman took roughly 40 sets to Rose City Comic Con as a trial run. On November 7, 2023, the store's **official Facebook page** announced a public display of the collection for November 11–12, using the $200,000 figure and listing **salem@bricksandminifigs.com** — a corporate-domain email — as the press contact. The event took place; the 83-year-old Eric Mansell attended and was photographed with Law-Gorman and the collection. Bryan posted publicly about the event on November 11.
+
+**Established (terms).** A consignment agreement was entered in **November 2023** with a roughly 65/35 split favoring Mansell, a clause obligating the operator to insure the collection, and a 30-day written termination provision. Title to unsold sets remained with Mansell until sale.
+
+**BAM's claim.** The agreement was an unauthorized personal side deal; corporate was never formally made aware of it; no insurance has been found.
+
+**Contradiction worth noting.** BAM's own timeline header dates the agreement to "October 2023," then its body says November 2023; the companion press release says November 2023. More substantively: the arrangement was promoted on the official store Facebook page using a corporate email address, at a public in-store event. That is difficult to square with the "purely personal, off-the-books" characterization. A collector dealing with the BAM operator, in the BAM store, via the BAM page and a BAM email, had every reason to believe he was dealing with Bricks & Minifigs. This is the apparent-authority question raised in *Miller v. McDonald's Corp.* and *Viado v. Domino's Pizza.*
+
+---
+
+## November 2023–October 2024 — Payments and tracking
+
+**Established / admitted.** For roughly a year, Bryan visited monthly to collect receipts and a check. He received approximately **$15,000** total. Law-Gorman marked his sets with small removable stickers to track them as consignment inventory.
+
+**BAM's claim.** Law-Gorman maintained "three separate spreadsheets" with differing figures; POS data shows "at least $52,000 and likely more" was sold during her tenure; she underreported sales to Bryan. (Sourced to "BAM June 4, 2026 Announcement" and Bryan's complaint.)
+
+**The math.** Even on BAM's own numbers, this phase shows an underpayment. If $52,000+ was sold and Mansell's share was ~65%, his payout should have been on the order of $33,000+. He received $15,000. BAM attributes the entire gap to Law-Gorman. But the POS that recorded those sales was BAM's own system — a point that becomes important once corporate, not Law-Gorman, controls the store.
+
+---
+
+## Late October–November 8, 2024 — Closure interest and a private agreement
+
+**BAM's claim (largely self-sourced).** In late October 2024, Law-Gorman contacted corporate about closing her store, citing her partner's job offer abroad. BAM says she owed just under **$200,000** in unpaid royalties, lease, and vendor bills, rendering her insolvent and triggering BAM's "security interest in the inventory." BAM says that on November 8 it agreed not to pursue the full $200,000 in exchange for a smooth handover on November 14, and that at no point did she mention a consignment collection.
+
+**Flag.** Almost this entire phase is sourced to "BAM team." The insolvency figure, the private November 8 agreement, and the claim that Law-Gorman never mentioned the consignment are unverifiable from the outside and are contested by Law-Gorman's own account. Note also the security-interest claim: a security interest attaches to the *store's* property, but consigned sets were Mansell's until sold. If corporate's inventory sweep included consigned goods, that is a problem the timeline raises and does not address.
+
+---
+
+## November 14, 2024 — The handover
+
+**Established.** Brandon Best arrived to take over the store. The transition was contentious. Law-Gorman recorded and later partially released Ring doorbell footage. A BAM worker, on that footage, responded to mention of a customer matter with words to the effect that it was Brandon's business to take on. Law-Gorman was terminated in writing that evening.
+
+**BAM's claim.** Law-Gorman became uncooperative, refused to surrender keys, made repeated trips to her car, removed cash from the till, and attempted to print store records; the word "consignment" was heard for the first time that night; the BAM worker's comment was not an acknowledgment of the Mansell collection but a misunderstanding during a chaotic handover; the store was left run-down with only ~$40,000 in inventory.
+
+**Contested — and a documented conflict.** Law-Gorman's account is that she was forced out under threat of police action and denied the chance to complete an inventory or keep her tracking spreadsheet, which remained in the store. Critically, her photographs from that evening — timestamped roughly 7:50–7:55 p.m. — reportedly show Star Wars sets bearing the yellow-dot identifying stickers **still on the store shelves.** Hold that against BAM's later claim (below) that the stickered sets were discovered weeks later in a back closet. Both cannot be a complete account.
+
+---
+
+## November 14–22, 2024 — Bryan comes to the store
+
+**Established.** Bryan tried to reach Law-Gorman on November 14, 15, and 18 with no response, then learned the store had changed hands. He visited the store, was met with confusion by the new operators, and was told BAM was not a party to his agreement. Josh walked him through the front of the store, where he could not identify his collection. He called police, who deemed it a civil matter. On November 22, 2024, he sent a certified-mail notice to Brandon Best at the Salem address terminating the consignment, citing the missed November installment and a refusal to allow inspection on November 21.
+
+**The framing problem.** BAM presents Bryan's inability to identify his collection "on display" as exculpatory. But BAM's own later account says ~25 of his sets were in a back closet, not on display. The same document that offers the observation explains why the observation is meaningless.
+
+---
+
+## Late November–December 2024 — The closet, and the offer
+
+**BAM's claim.** Best and Johnson discovered roughly 25 Star Wars sets in a closed back closet, "did not think anything of" the stickers, kept them segregated, and offered them to Bryan out of sympathy in December 2024; he declined.
+
+**Documented conflict.** This is the crux. BAM says the stickered sets were carefully segregated and offered back. The documented record (per reporting in this series) is that after the new operators told Bryan his sets were gone, the buyer he sent in **purchased one of his consigned sets with the identifying sticker removed from the UPC.** A set cannot be both safely segregated-and-offered-back and sold-off-the-floor-with-its-sticker-removed. Note also the date inconsistency between BAM's own posts: the timeline says the inventory was offered in December **2024**; the press release says "most recently in December **2025**."
+
+---
+
+## November 2024–April 2025 — Correspondence and going public
+
+**Established.** Bryan exchanged messages with BAM's corporate office and legal team through this period; no resolution was reached. Per reporting in this series, corporate told Bryan the evidence was insufficient and directed him to pursue Law-Gorman. On April 16, 2025, Bryan appeared on the *Collectors Weekly* podcast and laid out his account, including an inventory list and the Ring footage.
+
+**Flag.** BAM's two June 4 posts can't agree on the podcast's name — "Collecting Weekly" in one, "Collectors Weekly" in the other. Minor, but emblematic of the editing.
+
+---
+
+## Late 2024–2025 — The store changes hands
+
+**Established (per reporting in this series).** The third-party entity that conducted the post-seizure inventory **on corporate's behalf**, identified as Baker Bricks LLC, subsequently **purchased the store**, with Brandon Best and Joshua Johnson installed as operators (both reportedly relocating to Utah). Mansell reportedly obtained a default judgment in Oregon.
+
+**Open.** The sequence — the same party inventories the store for corporate, then buys it within roughly a month — is one of the unresolved threads BAM's June 4 timeline simply skips. Neither June 4 document explains how Baker Bricks went from corporate's inventory contractor to the store's owner, or what that means for the chain of custody over Mansell's collection.
+
+---
+
+## March 2026 — The American Fork episode
+
+**Established (per the American Fork PD account).** YouTuber Benjamin Schneider ("Reckless Ben"), who produced widely viewed videos about the case and raised funds online, traveled to American Fork, Utah, in connection with serving Joshua Johnson. American Fork Police Chief Cameron Paul released a roughly 26-minute statement on May 29, 2026, describing four police calls between March 8 and 11 and an alleged staged "UPS" delivery on March 8 that police say Schneider acknowledged was staged.
+
+**Open / neutral.** The conduct alleged here cuts in multiple directions and is itself disputed. I take no position on Schneider's conduct; it is a separate matter from the underlying consignment dispute, and BAM's posts lean on it heavily to recast the entire controversy as a harassment campaign. Readers should keep the two questions distinct: whether a collector was made whole, and how third parties behaved online and offline, are not the same question.
+
+---
+
+## May–June 2026 — The corporate posts and the TRO
+
+**Established.** BAM published a series of community-facing posts (May 21 and May 28, 2026) culminating in the June 4 press release and timeline. On May 28, 2026, a Utah court issued a temporary restraining order requiring the videos BAM characterizes as defamatory to be taken down. A GoFundMe for Bryan had raised over **$350,000** as of June 3, 2026.
+
+**Flag — what a TRO is and isn't.** A TRO ordering speech removed is a **prior restraint**, the most disfavored category of speech regulation in American law, and it reflects a court's preliminary assessment, not a final finding that the speech was false. As this series has noted regarding Oregon's anti-SLAPP statute (ORS 31.150) and the prior-restraint doctrine, a takedown order is not a verdict on the truth of the underlying reporting. BAM presenting it as vindication is an overclaim.
+
+**Flag — the GoFundMe line.** BAM drops the $350,000 figure into its key details without comment, next to its $95,000–$100,000 valuation. The implication — that the public over-gave — is left for the reader to draw. It is an insinuation, not an argument.
+
+---
+
+## June 4, 2026 — Closure and "mutual separation"
+
+**BAM's claim.** The Salem store is permanently closed and the Company has reached a "mutual" separation with Brandon Best and Joshua Johnson, "forced" by the online campaign. CEO Ammon McNeff publicly invites Bryan to sit down, review the spreadsheets and POS data, take any remaining Star Wars LEGO "whether identified as his or not," be made whole for anything unaccounted for, and indicates a willingness to potentially drop Bryan as a named defendant in BAM's lawsuit.
+
+**The throughline.** Read end to end, the timeline attributes essentially every failure to a departed former franchisee, casts the current owners as unwitting inheritors, and frames corporate as the diligent party that "finally" assembled the truth — while sourcing its most important claims to itself, contradicting the documented record on the stickers, contradicting its own companion post on at least three dates and names, and never accounting for what happened to the collection once corporate controlled the store. The stated reason for the separation is the social-media campaign. The conduct that prompted the campaign goes undescribed.
+
+---
+
+## What's actually unresolved
+
+Stripping the framing away, these are the open questions the June 4 documents do not answer:
+
+1. If the consignment was a purely personal side deal, why was it promoted on the official BAM store page using a corporate email at a public in-store event?
+2. If $52,000+ sold through BAM's own POS and Bryan received only $15,000, who holds the difference — and why is the entire gap assigned to a former franchisee when corporate controlled the same POS afterward?
+3. How were the stickered sets simultaneously "segregated in a closet and offered back" and sold off the floor with the sticker removed?
+4. How did corporate's inventory contractor, Baker Bricks LLC, come to own the store roughly a month later, and what did that mean for custody of Mansell's collection?
+5. Did corporate's asserted "security interest in the inventory" sweep in consigned goods that were never the franchisee's to pledge?
+6. What became of the collection after corporate took control of the premises, the POS, and the transition?
+
+A timeline that answered those would be an accounting. The one BAM published answers a different question: who to blame.
+
+------
+
+*Tony Guntharp writes at fusion94.org about technology, open source, and the things that matter. He is also a LEGO collector and knows exactly how much those Star Wars sets are worth.*
+
+---
+
+*This post is commentary on public corporate statements and on prior reporting, including the* Salem Business Journal *and* Kotaku*, cross-referenced against BAM's own June 4, 2026 timeline and press release. Allegations by all parties — BAM, the former franchisee, the current owners, Mr. Schneider, and Mr. Mansell — remain unproven unless and until established in court. Nothing here constitutes legal advice. Corrections and documentation are welcome at fusion94.org.*

--- a/src/content/blog/2026-06-05-bam-salem-press-release-blame-shift.md
+++ b/src/content/blog/2026-06-05-bam-salem-press-release-blame-shift.md
@@ -122,4 +122,9 @@ The most useful things in the two documents are the parts that escaped the messa
 
 ---
 
+*Tony Guntharp writes at fusion94.org about technology, open source, and the things that matter. He is also a LEGO collector and knows exactly how much those Star Wars sets are worth.*
+
+---
+
+
 *This post is commentary on public corporate statements and on prior reporting, including the* Salem Business Journal *and* Kotaku*. Allegations by all parties — BAM, the former franchisee, the current owners, Mr. Schneider, and Mr. Mansell — remain unproven unless and until established in court. Nothing here constitutes legal advice. Corrections and documentation are welcome at fusion94.org.*


### PR DESCRIPTION
## Summary

- Adds a companion investigative post that annotates Bricks & Minifigs corporate's own June 4, 2026 timeline ("What We Presently Believe Actually Happened") entry by entry.
- Separates established facts from BAM's self-attributed claims and flags where the company's version conflicts with the documented record.
- Adds a short author bio to the related blame-shift post for consistency across the series.

## Changes

- **content/blog**: New post `2026-06-05-bam-salem-annotated-timeline.md` — walks BAM's chronology, marking each phase as established / BAM's claim / contested or open.
- **content/blog**: Add author bio blurb to `2026-06-05-bam-salem-press-release-blame-shift.md`.

## Test Plan

- [x] `npm run dev` and confirm the new post renders at its slug
- [x] Frontmatter validates (title, pubDate, author, categories, tags, description, heroImage)
- [x] Author bio renders correctly on the blame-shift post
- [x] `npm run build` completes without content-collection errors
- [x] Hero image `/images/bam.webp` resolves
